### PR TITLE
Feat #2 스웨거 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	// web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -52,7 +53,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/unionmate/backend/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/unionmate/backend/global/config/PermitUrlConfig.java
@@ -1,0 +1,14 @@
+package com.unionmate.backend.global.config;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PermitUrlConfig {
+    public String[] getPublicUrl() {
+        return new String[]{
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/health-check"
+        };
+    }
+}

--- a/src/main/java/com/unionmate/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/unionmate/backend/global/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.unionmate.backend.global.config;
+
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final PermitUrlConfig permitUrlConfig;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfig() {
+        CorsConfiguration cfg = new CorsConfiguration();
+        cfg.setAllowedOrigins(List.of("*"));
+        cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        cfg.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        cfg.setExposedHeaders(List.of("Authorization", "RefreshToken"));
+        cfg.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
+        src.registerCorsConfiguration("/**", cfg);
+        return src;
+    }
+}

--- a/src/main/java/com/unionmate/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/unionmate/backend/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfig() {
         CorsConfiguration cfg = new CorsConfiguration();
-        cfg.setAllowedOrigins(List.of("*"));
+        cfg.setAllowedOriginPatterns(List.of("*"));
         cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         cfg.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         cfg.setExposedHeaders(List.of("Authorization", "RefreshToken"));

--- a/src/main/java/com/unionmate/backend/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/unionmate/backend/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.unionmate.backend.global.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    private static final String JWT_SCHEME = "jwtAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .addSecurityItem(new SecurityRequirement().addList(JWT_SCHEME))
+                .components(new Components()
+                        .addSecuritySchemes(JWT_SCHEME,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("Authorization")
+                        )
+                )
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("UnionMate")
+                .description("UnionMate API 문서")
+                .version("1.1.0");
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #1 

## 작업 내용 💻

- [x] 스웨거 config 추가
- [x] 의존성 설정 추가
- [x] 시큐티리 config

## 스크린샷 📷

<img width="1469" height="873" alt="image" src="https://github.com/user-attachments/assets/2b0b2479-9d62-4920-abee-40663ac7d6f2" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 스웨거랑 시큐리티 초기세팅 정도라 딱히 없었습니다
시큐리티는 임시 전체 허용해놨고, 추후 JWT 구현시 수정하면 될거같아요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - API 보안 구성 도입: 헬스체크·API 문서·Swagger UI 등 공개 엔드포인트 허용, 기본 보안 필터 및 메서드 수준 보안 설정 추가.
  - CORS 정책 추가: 모든 오리진 허용, 표준 메서드/헤더 허용, Authorization/RefreshToken 노출 및 크리덴셜 허용.
  - OpenAPI/Swagger 문서 개선: 루트 서버 설정, JWT Bearer 인증 스킴 및 보안 요구사항, 문서 정보 업데이트.
- Chores
  - 보안 관련 의존성 추가 및 OpenAPI Swagger UI 의존성 버전 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->