### PR TITLE
Refactor/#9 Netflix Eureka Client 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
+ext {
+	springCloudVersion = "2025.0.0"
+}
+
 group = 'com.unionmate'
 version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
@@ -28,6 +32,10 @@ dependencies {
 	// web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//Netflix Eureka Client
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -62,6 +70,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	//Netflix Eureka Client
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// lombok

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ server:
   port: 8080
 spring:
   application:
-    name: unionmate-dev
+    name: backend-service
   datasource:
     url: ENC(oRO52DvZxINLWMbcjagDrioNN7qY4StaIIdkGcb9Ijle0YjTBT233KnhoFpD0vAefjSagLxkVcFEszXiIhgqAO9CDBIs7DEnvQzEFLVSLfYE3oZ9Q0c9Z4+qt9NMijau)
     username: ENC(TSk7cZHU52AV+++x9lsqKw==)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: http://discovery-service-dev:8761/eureka
+      defaultZone: http://3.34.87.16:8761/eureka
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: http://3.34.87.16:8761/eureka
+      defaultZone: ENC(2Na13DVcC+KIm2zTPbStHdNqU/S0PMS0IDdKjderWsXYcoCwBMpf9w==)
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8080
 spring:
   application:
     name: unionmate-dev
@@ -13,5 +15,15 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://3.34.87.16:8761/eureka
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
 
 server-uri: ENC(H4s4yDrko9ywgpBMdg8jirml7A5q32cV8VQcuOigdAg=)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: http://3.34.87.16:8761/eureka
+      defaultZone: http://discovery-service-dev:8761/eureka
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,8 @@
+server:
+  port: 8080
 spring:
+  application:
+    name: backend-service
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
@@ -11,5 +15,14 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 
 server-uri: http://localhost:8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,8 @@
+server:
+  port: 8080
 spring:
   application:
-    name: unionmate-prod
+    name: backend-service
   datasource:
     url: ENC(uk+kZN986V4o7tQWSpLhd7PnhZFGrQK5YN8+uoMHoX6fvvcgCK9I7Evm/OqNYbQZBJ/W8iM0Psm+WYMgaccZW4kI3mow1mMmLb3six1by6r9FkWa/GgZBz1spzkTbnAR8tVQnimxe4o=)
     username: ENC(ikYX5Ve5hvRD47opu21rYA==)
@@ -13,5 +15,14 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: https://43.200.160.0.nip.io:8761/eureka
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 
 server-uri: ENC(ADvQZvUiEY6KHiaoUlImBAxMCbavYyrtNecYgfkx1ZxVOp4PhWAKrA==)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: https://43.200.160.0.nip.io:8761/eureka
+      defaultZone: http://discovery-service-prod:8761/eureka
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,0 @@
-spring:
-  jpa:
-    open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
 spring:
-  profiles:
-    active: local
   jpa:
     open-in-view: false


### PR DESCRIPTION
## Related issue 🛠

- closed #9 

## 작업 내용 💻

- [ ] Netflix Eureka Client 설정을 진행했습니다. 유레카 서버에 해당 서비스를 등록했습니다.
- [ ] 해당 레포지토리를 gateway-service의 라우터에 추가하여 8000번 포트에서 해당 서비스를 이용할 수 있도록 구현했습니다.

## 스크린샷 📷

### local 서버
<img width="1911" height="1009" alt="image" src="https://github.com/user-attachments/assets/24383dee-0cb7-4eb1-8897-d4d880bb9690" />
<img width="453" height="154" alt="image" src="https://github.com/user-attachments/assets/a7e07ad3-5b7d-43d1-b650-dfe548b64ce6" />

### dev 서버
<img width="1907" height="745" alt="image" src="https://github.com/user-attachments/assets/7cc48e4f-f34f-4c02-aab8-0a1f5d0e6823" />
<img width="513" height="172" alt="image" src="https://github.com/user-attachments/assets/2d0a2c98-f202-43ed-a262-177902315746" />

### prod 서버
<img width="1906" height="745" alt="image" src="https://github.com/user-attachments/assets/8cfcbb15-4a5f-4b52-ab4b-9f87d5146f8d" />
<img width="427" height="196" alt="image" src="https://github.com/user-attachments/assets/92e17f88-6a0f-4a98-8d79-c3b273c72b68" />


### 아키텍처 
최종적으로 구축한 prod 서버의 아키텍처는 다음과 같습니다. 
<img width="1041" height="509" alt="image" src="https://github.com/user-attachments/assets/67635cf5-7df7-4196-826a-43785421f9b9" />
<img width="1274" height="263" alt="image" src="https://github.com/user-attachments/assets/a18057f9-8f4e-44e1-9071-d60dd23d8cb1" />





## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 서비스 디스커버리(Eureka) 클라이언트 연동 — 레지스트리 등록 및 조회 지원
  * 운영 모니터링/헬스체크용 Actuator 엔드포인트 활성화

* **구성/환경**
  * 기본 서버 포트 8080으로 통일
  * 애플리케이션 이름을 backend-service로 통일
  * 로컬/개발/운영 환경에 Eureka 연결 정보(등록/조회, 서버 주소, 인스턴스 ID) 추가
  * Spring Cloud BOM 중앙관리용 속성 및 의존성 관리 추가
  * 기본 활성 프로필 및 JPA open-in-view 설정 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->