### PR TITLE
Feat/#22 지원서 조회 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/GetMyApplicationsRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/GetMyApplicationsRequest.java
@@ -1,0 +1,12 @@
+package com.unionmate.backend.domain.applicant.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GetMyApplicationsRequest(
+	@NotBlank
+	String name,
+
+	@NotBlank
+	String email
+) {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/GetMyApplicationsRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/GetMyApplicationsRequest.java
@@ -1,11 +1,14 @@
 package com.unionmate.backend.domain.applicant.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record GetMyApplicationsRequest(
+	@Schema(description = "지원자 이름", example = "김가천")
 	@NotBlank
 	String name,
 
+	@Schema(description = "지원자 이메일", example = "unionmate@unionmate.com")
 	@NotBlank
 	String email
 ) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/UpdateApplicationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/UpdateApplicationRequest.java
@@ -3,6 +3,7 @@ package com.unionmate.backend.domain.applicant.application.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 
 public record UpdateApplicationRequest(
 	@Schema(description = "지원자 이름", example = "김가천")
@@ -15,6 +16,6 @@ public record UpdateApplicationRequest(
 	String tel,
 
 	@Schema(description = "문항별 답변 목록")
-	List<AnswerRequest> answers
+	List<@Valid AnswerRequest> answers
 ) {
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/UpdateApplicationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/UpdateApplicationRequest.java
@@ -2,10 +2,19 @@ package com.unionmate.backend.domain.applicant.application.dto.request;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UpdateApplicationRequest(
+	@Schema(description = "지원자 이름", example = "김가천")
 	String name,
+
+	@Schema(description = "지원자 이메일", example = "unionmate@unionmate.com")
 	String email,
+
+	@Schema(description = "지원자 연락처", example = "010123411234")
 	String tel,
+
+	@Schema(description = "문항별 답변 목록")
 	List<AnswerRequest> answers
 ) {
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/UpdateApplicationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/UpdateApplicationRequest.java
@@ -1,0 +1,11 @@
+package com.unionmate.backend.domain.applicant.application.dto.request;
+
+import java.util.List;
+
+public record UpdateApplicationRequest(
+	String name,
+	String email,
+	String tel,
+	List<AnswerRequest> answers
+) {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/ApplicationAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/ApplicationAnswerResponse.java
@@ -1,0 +1,14 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+
+public sealed interface ApplicationAnswerResponse
+	permits TextAnswerResponse, SelectAnswerResponse, CalendarAnswerResponse {
+	ItemType itemType();
+
+	String title();
+
+	Integer order();
+
+	String description();
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/ApplicationAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/ApplicationAnswerResponse.java
@@ -1,6 +1,11 @@
 package com.unionmate.backend.domain.applicant.application.dto.response;
 
+import com.unionmate.backend.domain.recruitment.application.exception.ItemTypeNotExistException;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.TextItem;
 
 public sealed interface ApplicationAnswerResponse
 	permits TextAnswerResponse, SelectAnswerResponse, CalendarAnswerResponse {
@@ -11,4 +16,13 @@ public sealed interface ApplicationAnswerResponse
 	Integer order();
 
 	String description();
+
+	static ApplicationAnswerResponse from(Item item) {
+		return switch (item) {
+			case TextItem textItem -> TextAnswerResponse.from(textItem);
+			case SelectItem selectItem -> SelectAnswerResponse.from(selectItem);
+			case CalendarItem calendarItem -> CalendarAnswerResponse.from(calendarItem);
+			default -> throw new ItemTypeNotExistException();
+		};
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
@@ -3,12 +3,25 @@ package com.unionmate.backend.domain.applicant.application.dto.response;
 import java.time.LocalDate;
 
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
 
 public record CalendarAnswerResponse(
 	ItemType itemType,
 	String title,
 	Integer order,
 	String description,
-	LocalDate date
+	LocalDate date,
+	LocalDate answer
 ) implements ApplicationAnswerResponse {
+
+	public static CalendarAnswerResponse from(CalendarItem calendarItem) {
+		return new CalendarAnswerResponse(
+			ItemType.CALENDAR,
+			calendarItem.getTitle(),
+			calendarItem.getOrder(),
+			calendarItem.getDescription(),
+			calendarItem.getDate(),
+			calendarItem.getAnswer() == null ? null : calendarItem.getAnswer().answer()
+		);
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
@@ -1,0 +1,14 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import java.time.LocalDate;
+
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+
+public record CalendarAnswerResponse(
+	ItemType itemType,
+	String title,
+	Integer order,
+	String description,
+	LocalDate date
+) implements ApplicationAnswerResponse {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
@@ -5,12 +5,25 @@ import java.time.LocalDate;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record CalendarAnswerResponse(
+	@Schema(description = "항목 타입 (TEXT, SELECT, CALENDAR, ANNOUNCEMENT)", example = "CALENDAR")
 	ItemType itemType,
+
+	@Schema(description = "항목 제목", example = "날짜 선택")
 	String title,
+
+	@Schema(description = "표시 순서 (1부터 시작)", example = "1")
 	Integer order,
+
+	@Schema(description = "항목 설명 안내", example = "해당 날짜 전까지 희망하는 날짜를 작성해주세요")
 	String description,
+
+	@Schema(description = "날짜 지정", example = "2025-12-31")
 	LocalDate date,
+
+	@Schema(description = "답변 날짜")
 	LocalDate answer
 ) implements ApplicationAnswerResponse {
 

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
@@ -10,6 +10,9 @@ public record GetApplicationResponse(
 	Long applicationId,
 	Long recruitmentId,
 	String recruitmentName,
+	String name,
+	String email,
+	String tel,
 	List<ApplicationAnswerResponse> answers
 ) {
 	public static GetApplicationResponse from(Application application) {
@@ -22,6 +25,9 @@ public record GetApplicationResponse(
 			application.getId(),
 			application.getRecruitment().getId(),
 			application.getRecruitment().getName(),
+			application.getName(),
+			application.getEmail(),
+			application.getTel(),
 			answer
 		);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
@@ -1,0 +1,12 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import java.util.List;
+
+public record GetApplicationResponse(
+	Long applicationId,
+	Long recruitmentId,
+	String recruitmentName,
+	List<ApplicationAnswerResponse> answers
+) {
+
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
@@ -6,12 +6,25 @@ import java.util.List;
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record GetApplicationResponse(
+	@Schema(description = "지원서 id", example = "1")
 	Long applicationId,
+
+	@Schema(description = "지원서 양식 id", example = "1")
 	Long recruitmentId,
+
+	@Schema(description = "지원서 이름", example = "25대 컴퓨터공학과 학생회 모집")
 	String recruitmentName,
+
+	@Schema(description = "지원자 이름", example = "김가천")
 	String name,
+
+	@Schema(description = "지원자 이메일", example = "unionmate@unionmate.com")
 	String email,
+
+	@Schema(description = "지원자 전화번호", example = "010-6658-6316")
 	String tel,
 	List<ApplicationAnswerResponse> answers
 ) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
@@ -1,6 +1,10 @@
 package com.unionmate.backend.domain.applicant.application.dto.response;
 
+import java.util.Comparator;
 import java.util.List;
+
+import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
 
 public record GetApplicationResponse(
 	Long applicationId,
@@ -8,5 +12,17 @@ public record GetApplicationResponse(
 	String recruitmentName,
 	List<ApplicationAnswerResponse> answers
 ) {
+	public static GetApplicationResponse from(Application application) {
+		List<ApplicationAnswerResponse> answer = application.getAnswers().stream()
+			.sorted(Comparator.comparing(Item::getOrder))
+			.map(ApplicationAnswerResponse::from)
+			.toList();
 
+		return new GetApplicationResponse(
+			application.getId(),
+			application.getRecruitment().getId(),
+			application.getRecruitment().getName(),
+			answer
+		);
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetMyApplicationsResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetMyApplicationsResponse.java
@@ -3,10 +3,19 @@ package com.unionmate.backend.domain.applicant.application.dto.response;
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record GetMyApplicationsResponse(
+	@Schema(description = "지원서 id", example = "1")
 	Long applicationId,
+
+	@Schema(description = "지원서 양식 id", example = "1")
 	Long recruitmentId,
+
+	@Schema(description = "지원서 이름", example = "25대 컴퓨터공학과 학생회 모집")
 	String recruitmentName,
+
+	@Schema(description = "지원서 상태(DOCUMENT_SCREENING, INTERVIEW, FINAL", example = "DOCUMENT_SCREENING")
 	RecruitmentStatus recruitmentStatus
 ) {
 	public static GetMyApplicationsResponse from(Application application) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetMyApplicationsResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetMyApplicationsResponse.java
@@ -1,0 +1,20 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
+
+public record GetMyApplicationsResponse(
+	Long applicationId,
+	Long recruitmentId,
+	String recruitmentName,
+	RecruitmentStatus recruitmentStatus
+) {
+	public static GetMyApplicationsResponse from(Application application) {
+		return new GetMyApplicationsResponse(
+			application.getId(),
+			application.getRecruitment().getId(),
+			application.getRecruitment().getName(),
+			application.getStage().recruitmentStatus()
+		);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -16,7 +16,7 @@ public record SelectAnswerResponse(
 
 	public static SelectAnswerResponse from(SelectItem selectItem) {
 		return new SelectAnswerResponse(
-			ItemType.TEXT,
+			ItemType.SELECT,
 			selectItem.getTitle(),
 			selectItem.getOrder(),
 			selectItem.getDescription(),

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -3,6 +3,7 @@ package com.unionmate.backend.domain.applicant.application.dto.response;
 import java.util.List;
 
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
 
 public record SelectAnswerResponse(
 	ItemType itemType,
@@ -12,4 +13,15 @@ public record SelectAnswerResponse(
 	boolean multiple,
 	List<Long> selectedOptionIds
 ) implements ApplicationAnswerResponse {
+
+	public static SelectAnswerResponse from(SelectItem selectItem) {
+		return new SelectAnswerResponse(
+			ItemType.TEXT,
+			selectItem.getTitle(),
+			selectItem.getOrder(),
+			selectItem.getDescription(),
+			selectItem.isMultiple(),
+			selectItem.getAnswer() == null ? List.of() : selectItem.getAnswer().answer()
+		);
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -5,12 +5,25 @@ import java.util.List;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record SelectAnswerResponse(
+	@Schema(description = "항목 타입 (TEXT, SELECT, CALENDAR, ANNOUNCEMENT)", example = "SELECT")
 	ItemType itemType,
+
+	@Schema(description = "항목 제목", example = "날짜 선택")
 	String title,
+
+	@Schema(description = "표시 순서 (1부터 시작)", example = "1")
 	Integer order,
+
+	@Schema(description = "항목 설명 안내", example = "해당 날짜 전까지 희망하는 날짜를 작성해주세요")
 	String description,
+
+	@Schema(description = "중복 선택 가능 여부 ", example = "false")
 	boolean multiple,
+
+	@Schema(description = "답변한 선택지")
 	List<Long> selectedOptionIds
 ) implements ApplicationAnswerResponse {
 

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -1,0 +1,15 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import java.util.List;
+
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+
+public record SelectAnswerResponse(
+	ItemType itemType,
+	String title,
+	Integer order,
+	String description,
+	boolean multiple,
+	List<Long> selectedOptionIds
+) implements ApplicationAnswerResponse {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
@@ -1,0 +1,12 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+
+public record TextAnswerResponse(
+	ItemType itemType,
+	String title,
+	Integer order,
+	String description,
+	String text
+) implements ApplicationAnswerResponse {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
@@ -9,7 +9,7 @@ public record TextAnswerResponse(
 	Integer order,
 	String description,
 	Integer maxLength,
-	String text
+	String answer
 ) implements ApplicationAnswerResponse {
 
 	public static TextAnswerResponse from(TextItem textItem) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
@@ -3,12 +3,25 @@ package com.unionmate.backend.domain.applicant.application.dto.response;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.TextItem;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record TextAnswerResponse(
+	@Schema(description = "항목 타입 (TEXT, SELECT, CALENDAR, ANNOUNCEMENT)", example = "TEXT")
 	ItemType itemType,
+
+	@Schema(description = "항목 제목", example = "날짜 선택")
 	String title,
+
+	@Schema(description = "표시 순서 (1부터 시작)", example = "1")
 	Integer order,
+
+	@Schema(description = "항목 설명 안내", example = "해당 날짜 전까지 희망하는 날짜를 작성해주세요")
 	String description,
+
+	@Schema(description = "답변 최대 글자수", example = "700")
 	Integer maxLength,
+
+	@Schema(description = "질문 답변")
 	String answer
 ) implements ApplicationAnswerResponse {
 

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/TextAnswerResponse.java
@@ -1,12 +1,25 @@
 package com.unionmate.backend.domain.applicant.application.dto.response;
 
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.TextItem;
 
 public record TextAnswerResponse(
 	ItemType itemType,
 	String title,
 	Integer order,
 	String description,
+	Integer maxLength,
 	String text
 ) implements ApplicationAnswerResponse {
+
+	public static TextAnswerResponse from(TextItem textItem) {
+		return new TextAnswerResponse(
+			ItemType.TEXT,
+			textItem.getTitle(),
+			textItem.getOrder(),
+			textItem.getDescription(),
+			textItem.getMaxLength(),
+			textItem.getAnswer() == null ? null : textItem.getAnswer().answer()
+		);
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ApplicationNotFoundException.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ApplicationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.unionmate.backend.domain.applicant.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.unionmate.backend.exception.ApplicationException;
+
+public class ApplicationNotFoundException extends ApplicationException {
+	public ApplicationNotFoundException() {
+		super(ErrorCode.APPLICATION_NOT_FOUND, HttpStatus.NOT_FOUND);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ApplicationUpdateInvalidException.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ApplicationUpdateInvalidException.java
@@ -1,0 +1,11 @@
+package com.unionmate.backend.domain.applicant.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.unionmate.backend.exception.ApplicationException;
+
+public class ApplicationUpdateInvalidException extends ApplicationException {
+	public ApplicationUpdateInvalidException() {
+		super(ErrorCode.APPLICATION_UPDATE_INVALID, HttpStatus.BAD_REQUEST);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ErrorCode.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode implements ErrorInfo {
 	OPTION_INVALID("유효하지 않은 선택지입니다.", 2106),
 	PLURAL_SELECT_INVALID("중복 선택이 불가능한 항목입니다.", 2107),
 	RECRUITMENT_CLOSED("현재 지원 기간이 아닙니다.", 2108),
-	ITEM_ANSWER_DUPLICATE("동일한 질문에 중복된 답변을 하였습니다.", 2109);
+	ITEM_ANSWER_DUPLICATE("동일한 질문에 중복된 답변을 하였습니다.", 2109),
+	APPLICATION_NOT_FOUND("해당 지원서를 찾을 수 없습니다.", 2110);
 
 	private final String message;
 	private final Integer code;

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ErrorCode.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode implements ErrorInfo {
 	PLURAL_SELECT_INVALID("중복 선택이 불가능한 항목입니다.", 2107),
 	RECRUITMENT_CLOSED("현재 지원 기간이 아닙니다.", 2108),
 	ITEM_ANSWER_DUPLICATE("동일한 질문에 중복된 답변을 하였습니다.", 2109),
-	APPLICATION_NOT_FOUND("해당 지원서를 찾을 수 없습니다.", 2110);
+	APPLICATION_NOT_FOUND("해당 지원서를 찾을 수 없습니다.", 2110),
+	APPLICATION_UPDATE_INVALID("해당 지원서를 수정할 수 있는 기간이 아닙니다.", 2111);
 
 	private final String message;
 	private final Integer code;

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -1,5 +1,6 @@
 package com.unionmate.backend.domain.applicant.application.usecase;
 
+import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.exception.DuplicateItemAnswerException;
 import com.unionmate.backend.domain.applicant.application.util.CalendarAnswerValidator;
@@ -154,5 +155,11 @@ public class ApplicationUseCase {
 			.stream()
 			.map(GetMyApplicationsResponse::from)
 			.toList();
+	}
+
+	public GetApplicationResponse getApplication(Long applicationId) {
+		Application application = applicationGetService.getApplicationById(applicationId);
+
+		return GetApplicationResponse.from(application);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -60,10 +60,12 @@ public class ApplicationUseCase {
 	private final UpdateAnswerValidator updateAnswerValidator;
 
 	@Transactional
-	public void submitApplication(Long recruitmentId, CreateApplicantRequest createApplicantRequest) {
+	public void submitApplication(
+		Long recruitmentId, CreateApplicantRequest createApplicantRequest, LocalDateTime now
+	) {
 		Recruitment recruitment = recruitmentGetService.getRecruitmentById(recruitmentId);
 
-		if (!recruitment.isOpen(LocalDateTime.now())) {
+		if (!recruitment.isOpen(now)) {
 			throw new RecruitmentInvalidException();
 		}
 

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -1,5 +1,6 @@
 package com.unionmate.backend.domain.applicant.application.usecase;
 
+import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.exception.DuplicateItemAnswerException;
 import com.unionmate.backend.domain.applicant.application.util.CalendarAnswerValidator;
 import com.unionmate.backend.domain.applicant.application.util.SelectAnswerValidator;
@@ -27,6 +28,7 @@ import com.unionmate.backend.domain.applicant.application.exception.RecruitmentI
 import com.unionmate.backend.domain.applicant.application.exception.RequiredAnswerMissingException;
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.applicant.domain.entity.column.Answer;
+import com.unionmate.backend.domain.applicant.domain.service.ApplicationGetService;
 import com.unionmate.backend.domain.applicant.domain.service.ApplicationSaveService;
 import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
@@ -40,9 +42,11 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ApplicationUseCase {
 	private final ApplicationSaveService applicationSaveService;
 	private final RecruitmentGetService recruitmentGetService;
+	private final ApplicationGetService applicationGetService;
 	private final TextAnswerValidator textAnswerValidator;
 	private final SelectAnswerValidator selectAnswerValidator;
 	private final CalendarAnswerValidator calendarAnswerValidator;
@@ -143,5 +147,12 @@ public class ApplicationUseCase {
 		}
 
 		applicationSaveService.save(application);
+	}
+
+	public List<GetMyApplicationsResponse> getMyApplications(String name, String email) {
+		return applicationGetService.getMyApplications(name, email)
+			.stream()
+			.map(GetMyApplicationsResponse::from)
+			.toList();
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -173,7 +173,7 @@ public class ApplicationUseCase {
 		Map<Long, Item> templateById = recruitment.getItems()
 			.stream().collect(Collectors.toMap(Item::getId, item -> item));
 
-		Map<Long, Item> existingAnswer = ExistingAnswers(application, recruitment);
+		Map<Long, Item> existingAnswer = existingAnswers(application, recruitment);
 
 		if (updateApplicationRequest.answers() != null) {
 			Set<Long> seen = new HashSet<>();
@@ -281,7 +281,7 @@ public class ApplicationUseCase {
 		return GetApplicationResponse.from(application);
 	}
 
-	private Map<Long, Item> ExistingAnswers(Application application, Recruitment recruitment) {
+	private Map<Long, Item> existingAnswers(Application application, Recruitment recruitment) {
 		Map<Long, Item> map = new HashMap<>();
 		List<Item> answers = application.getAnswers();
 

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -1,17 +1,21 @@
 package com.unionmate.backend.domain.applicant.application.usecase;
 
 import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
+import com.unionmate.backend.domain.applicant.application.exception.ApplicationUpdateInvalidException;
 import com.unionmate.backend.domain.applicant.application.exception.DuplicateItemAnswerException;
 import com.unionmate.backend.domain.applicant.application.util.CalendarAnswerValidator;
 import com.unionmate.backend.domain.applicant.application.util.SelectAnswerValidator;
 import com.unionmate.backend.domain.applicant.application.util.TextAnswerValidator;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,6 +32,7 @@ import com.unionmate.backend.domain.applicant.application.exception.ItemNotFound
 import com.unionmate.backend.domain.applicant.application.exception.ItemTypeMismatchException;
 import com.unionmate.backend.domain.applicant.application.exception.RecruitmentInvalidException;
 import com.unionmate.backend.domain.applicant.application.exception.RequiredAnswerMissingException;
+import com.unionmate.backend.domain.applicant.application.util.UpdateAnswerValidator;
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.applicant.domain.entity.column.Answer;
 import com.unionmate.backend.domain.applicant.domain.service.ApplicationGetService;
@@ -52,6 +57,7 @@ public class ApplicationUseCase {
 	private final TextAnswerValidator textAnswerValidator;
 	private final SelectAnswerValidator selectAnswerValidator;
 	private final CalendarAnswerValidator calendarAnswerValidator;
+	private final UpdateAnswerValidator updateAnswerValidator;
 
 	@Transactional
 	public void submitApplication(Long recruitmentId, CreateApplicantRequest createApplicantRequest) {
@@ -151,6 +157,116 @@ public class ApplicationUseCase {
 		applicationSaveService.save(application);
 	}
 
+	@Transactional
+	public void updateApplication(Long applicationId, UpdateApplicationRequest updateApplicationRequest) {
+		Application application = applicationGetService.getApplicationById(applicationId);
+		Recruitment recruitment = application.getRecruitment();
+
+		if (!recruitment.isOpen(LocalDateTime.now())) {
+			throw new ApplicationUpdateInvalidException();
+		}
+
+		application.updateIfPresent(
+			updateApplicationRequest.name(), updateApplicationRequest.email(), updateApplicationRequest.tel()
+		);
+
+		Map<Long, Item> templateById = recruitment.getItems()
+			.stream().collect(Collectors.toMap(Item::getId, item -> item));
+
+		Map<Long, Item> existingAnswer = ExistingAnswers(application, recruitment);
+
+		if (updateApplicationRequest.answers() != null) {
+			Set<Long> seen = new HashSet<>();
+			for (AnswerRequest answer : updateApplicationRequest.answers()) {
+				Item itemTemplate = templateById.get(answer.itemId());
+				if (itemTemplate == null) {
+					throw new ItemNotFoundException();
+				}
+
+				if (!seen.add(itemTemplate.getId())) {
+					throw new DuplicateItemAnswerException();
+				}
+
+				switch (itemTemplate.getItemType()) {
+					case TEXT -> {
+						if (!(answer instanceof TextAnswerRequest textAnswerRequest)
+							|| !(itemTemplate instanceof TextItem textItem)) {
+							throw new ItemTypeMismatchException();
+						}
+
+						textAnswerValidator.validate(textItem, textAnswerRequest);
+
+						Item existingItem = existingAnswer.get(itemTemplate.getId());
+						if (existingItem instanceof TextItem item) {
+							item.updateAnswer(new Answer<>(textAnswerRequest.text()));
+						} else {
+							TextItem newTextItem = TextItem.createApplicationText(
+								application, textItem.getRequired(), textItem.getTitle(), textItem.getOrder(),
+								textItem.getDescription(), textItem.getMaxLength()
+							);
+
+							newTextItem.updateAnswer(new Answer<>(textAnswerRequest.text()));
+							application.getAnswers().add(newTextItem);
+							existingAnswer.put(itemTemplate.getId(), newTextItem);
+						}
+					}
+
+					case SELECT -> {
+						if (!(answer instanceof SelectAnswerRequest selectAnswerRequest)
+							|| !(itemTemplate instanceof SelectItem selectItem)) {
+							throw new ItemTypeMismatchException();
+						}
+
+						selectAnswerValidator.validate(selectItem, selectAnswerRequest);
+
+						List<Long> selection = Optional.ofNullable(selectAnswerRequest.optionIds()).orElse(List.of());
+
+						Item existingItem = existingAnswer.get(itemTemplate.getId());
+						if (existingItem instanceof SelectItem item) {
+							item.updateAnswer(new Answer<>(selection));
+						} else {
+							SelectItem newSelectItem = SelectItem.createApplicationSelect(
+								application, selectItem.getRequired(), selectItem.getTitle(), selectItem.getOrder(),
+								selectItem.getDescription(), selectItem.isMultiple()
+							);
+
+							newSelectItem.updateAnswer(new Answer<>(selection));
+							application.getAnswers().add(newSelectItem);
+							existingAnswer.put(itemTemplate.getId(), newSelectItem);
+						}
+					}
+
+					case CALENDAR -> {
+						if (!(answer instanceof CalendarAnswerRequest calendarAnswerRequest)
+							|| !(itemTemplate instanceof CalendarItem calendarItem)) {
+							throw new ItemTypeMismatchException();
+						}
+
+						calendarAnswerValidator.validate(calendarItem, calendarAnswerRequest);
+
+						Item existingItem = existingAnswer.get(calendarItem.getId());
+						if (existingItem instanceof CalendarItem item) {
+							item.updateAnswer(new Answer<>(calendarAnswerRequest.date()));
+						} else {
+							CalendarItem newCalendarItem = CalendarItem.createApplicationCalendar(
+								application, calendarItem.getRequired(), calendarItem.getTitle(),
+								calendarItem.getOrder(), calendarItem.getDescription(), calendarItem.getDate()
+							);
+
+							newCalendarItem.updateAnswer(new Answer<>(calendarAnswerRequest.date()));
+							application.getAnswers().add(newCalendarItem);
+							existingAnswer.put(itemTemplate.getId(), newCalendarItem);
+						}
+					}
+				}
+			}
+		}
+
+		updateAnswerValidator.validateRequiredAnswers(application, recruitment);
+
+		applicationSaveService.save(application);
+	}
+
 	public List<GetMyApplicationsResponse> getMyApplications(GetMyApplicationsRequest getMyApplicationsRequest) {
 		return applicationGetService.getMyApplications(
 				getMyApplicationsRequest.name(), getMyApplicationsRequest.email())
@@ -163,5 +279,19 @@ public class ApplicationUseCase {
 		Application application = applicationGetService.getApplicationById(applicationId);
 
 		return GetApplicationResponse.from(application);
+	}
+
+	private Map<Long, Item> ExistingAnswers(Application application, Recruitment recruitment) {
+		Map<Long, Item> map = new HashMap<>();
+		List<Item> answers = application.getAnswers();
+
+		for (Item item : recruitment.getItems()) {
+			answers.stream()
+				.filter(answer -> answer.getItemType() == item.getItemType()
+					&& Objects.equals(answer.getTitle(), item.getTitle())
+					&& Objects.equals(answer.getOrder(), item.getOrder()))
+				.findFirst().ifPresent(matched -> map.put(item.getId(), matched));
+		}
+		return map;
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -1,5 +1,6 @@
 package com.unionmate.backend.domain.applicant.application.usecase;
 
+import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.exception.DuplicateItemAnswerException;
@@ -150,8 +151,9 @@ public class ApplicationUseCase {
 		applicationSaveService.save(application);
 	}
 
-	public List<GetMyApplicationsResponse> getMyApplications(String name, String email) {
-		return applicationGetService.getMyApplications(name, email)
+	public List<GetMyApplicationsResponse> getMyApplications(GetMyApplicationsRequest getMyApplicationsRequest) {
+		return applicationGetService.getMyApplications(
+				getMyApplicationsRequest.name(), getMyApplicationsRequest.email())
 			.stream()
 			.map(GetMyApplicationsResponse::from)
 			.toList();

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/util/UpdateAnswerValidator.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/util/UpdateAnswerValidator.java
@@ -1,0 +1,68 @@
+package com.unionmate.backend.domain.applicant.application.util;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import com.unionmate.backend.domain.applicant.application.exception.RequiredAnswerMissingException;
+import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.applicant.domain.entity.column.Answer;
+import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.TextItem;
+
+@Component
+public class UpdateAnswerValidator {
+	public void validateRequiredAnswers(Application application, Recruitment recruitment) {
+		boolean missing = recruitment.getItems().stream()
+			.filter(item -> item.getItemType() != ItemType.ANNOUNCEMENT)
+			.filter(item -> Boolean.TRUE.equals(item.getRequired()))
+			.anyMatch(item -> !hasNonEmptyAnswer(application, item));
+
+		if (missing) {
+			throw new RequiredAnswerMissingException();
+		}
+	}
+
+	private boolean hasNonEmptyAnswer(Application application, Item item) {
+		return application.getAnswers().stream()
+			.anyMatch(answer -> {
+				if (answer.getItemType() != item.getItemType()) {
+					return false;
+				}
+				if (!Objects.equals(answer.getTitle(), item.getTitle())) {
+					return false;
+				}
+				if (!Objects.equals(answer.getOrder(), item.getOrder())) {
+					return false;
+				}
+
+				return switch (answer.getItemType()) {
+					case TEXT -> {
+						TextItem textItem = (TextItem)answer;
+						Answer<String> a = textItem.getAnswer();
+						yield a != null & Objects.requireNonNull(a).answer() != null && !a.answer().isBlank();
+					}
+
+					case SELECT -> {
+						SelectItem selectItem = (SelectItem)answer;
+						Answer<List<Long>> a = selectItem.getAnswer();
+						yield a != null & Objects.requireNonNull(a).answer() != null && !a.answer().isEmpty();
+					}
+
+					case CALENDAR -> {
+						CalendarItem calendarItem = (CalendarItem)answer;
+						Answer<LocalDate> a = calendarItem.getAnswer();
+						yield a != null & Objects.requireNonNull(a).answer() != null;
+					}
+
+					case ANNOUNCEMENT -> true;
+				};
+			});
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/util/UpdateAnswerValidator.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/util/UpdateAnswerValidator.java
@@ -46,19 +46,19 @@ public class UpdateAnswerValidator {
 					case TEXT -> {
 						TextItem textItem = (TextItem)answer;
 						Answer<String> a = textItem.getAnswer();
-						yield a != null & Objects.requireNonNull(a).answer() != null && !a.answer().isBlank();
+						yield a != null && Objects.requireNonNull(a).answer() != null && !a.answer().isBlank();
 					}
 
 					case SELECT -> {
 						SelectItem selectItem = (SelectItem)answer;
 						Answer<List<Long>> a = selectItem.getAnswer();
-						yield a != null & Objects.requireNonNull(a).answer() != null && !a.answer().isEmpty();
+						yield a != null && Objects.requireNonNull(a).answer() != null && !a.answer().isEmpty();
 					}
 
 					case CALENDAR -> {
 						CalendarItem calendarItem = (CalendarItem)answer;
 						Answer<LocalDate> a = calendarItem.getAnswer();
-						yield a != null & Objects.requireNonNull(a).answer() != null;
+						yield a != null && Objects.requireNonNull(a).answer() != null;
 					}
 
 					case ANNOUNCEMENT -> true;

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/entity/Application.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/entity/Application.java
@@ -59,6 +59,15 @@ public class Application extends BaseEntity {
 	@Builder.Default
 	private List<Item> answers = new ArrayList<>();
 
+	public void updateIfPresent(String name, String email, String tel) {
+		if (name != null)
+			this.name = name;
+		if (email != null)
+			this.email = email;
+		if (tel != null)
+			this.tel = tel;
+	}
+
 	public static Application createApplication(String name, String email, String tel, Recruitment recruitment) {
 		return Application.builder()
 			.name(name)

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -1,8 +1,11 @@
 package com.unionmate.backend.domain.applicant.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+	List<Application> findAllByNameAndEmailOrderByIdDesc(String name, String email);
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.unionmate.backend.domain.applicant.application.exception.ApplicationNotFoundException;
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.applicant.domain.repository.ApplicationRepository;
 
@@ -16,5 +17,10 @@ public class ApplicationGetService {
 
 	public List<Application> getMyApplications(String name, String email) {
 		return applicationRepository.findAllByNameAndEmailOrderByIdDesc(name, email);
+	}
+
+	public Application getApplicationById(Long applicationId) {
+		return applicationRepository.findById(applicationId)
+			.orElseThrow(ApplicationNotFoundException::new);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
@@ -1,0 +1,20 @@
+package com.unionmate.backend.domain.applicant.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.applicant.domain.repository.ApplicationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationGetService {
+	private final ApplicationRepository applicationRepository;
+
+	public List<Application> getMyApplications(String name, String email) {
+		return applicationRepository.findAllByNameAndEmailOrderByIdDesc(name, email);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -1,5 +1,8 @@
 package com.unionmate.backend.domain.applicant.presentation;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -7,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
+import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationUseCase;
 import com.unionmate.backend.global.response.CommonResponse;
 
@@ -27,5 +31,14 @@ public class ApplicationController {
 		applicationUseCase.submitApplication(recruitmentId, createApplicantRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.SUBMIT_APPLICATION);
+	}
+
+	@GetMapping("/{name}/{email}")
+	@Operation(summary = "자신이 작성한 지원서 목록을 조회합니다.")
+	public CommonResponse<List<GetMyApplicationsResponse>> getMyApplications(
+		@PathVariable String name, @PathVariable String email) {
+		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(name, email);
+
+		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -35,7 +35,7 @@ public class ApplicationController {
 		return CommonResponse.success(ApplicationResponseCode.SUBMIT_APPLICATION);
 	}
 
-	@GetMapping("/{name}/{email}")
+	@GetMapping("/mine")
 	@Operation(summary = "자신이 작성한 지원서 목록을 조회합니다.")
 	public CommonResponse<List<GetMyApplicationsResponse>> getMyApplications(
 		GetMyApplicationsRequest getMyApplicationsRequest) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -38,7 +38,7 @@ public class ApplicationController {
 	@GetMapping("/{name}/{email}")
 	@Operation(summary = "자신이 작성한 지원서 목록을 조회합니다.")
 	public CommonResponse<List<GetMyApplicationsResponse>> getMyApplications(
-		@RequestBody GetMyApplicationsRequest getMyApplicationsRequest) {
+		GetMyApplicationsRequest getMyApplicationsRequest) {
 		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(getMyApplicationsRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -50,7 +50,7 @@ public class ApplicationController {
 	@GetMapping("/mine")
 	@Operation(summary = "자신이 작성한 지원서 목록을 조회합니다.")
 	public CommonResponse<List<GetMyApplicationsResponse>> getMyApplications(
-		GetMyApplicationsRequest getMyApplicationsRequest) {
+		@Valid GetMyApplicationsRequest getMyApplicationsRequest) {
 		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(getMyApplicationsRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -3,6 +3,7 @@ package com.unionmate.backend.domain.applicant.presentation;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationUseCase;
@@ -33,6 +35,16 @@ public class ApplicationController {
 		applicationUseCase.submitApplication(recruitmentId, createApplicantRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.SUBMIT_APPLICATION);
+	}
+
+	@PatchMapping("/{applicationId}")
+	@Operation(summary = "지원서를 수정합니다.")
+	public CommonResponse<Void> updateApplication(
+		@PathVariable Long applicationId, @Valid @RequestBody UpdateApplicationRequest updateApplicationRequest
+	) {
+		applicationUseCase.updateApplication(applicationId, updateApplicationRequest);
+
+		return CommonResponse.success(ApplicationResponseCode.UPDATE_APPLICATION);
 	}
 
 	@GetMapping("/mine")

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
+import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationUseCase;
 import com.unionmate.backend.global.response.CommonResponse;
@@ -40,5 +41,13 @@ public class ApplicationController {
 		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(name, email);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);
+	}
+
+	@GetMapping("/{applicationId}")
+	@Operation(summary = "특정 지원서를 조회합니다.")
+	public CommonResponse<GetApplicationResponse> getApplication(@PathVariable Long applicationId) {
+		GetApplicationResponse application = applicationUseCase.getApplication(applicationId);
+
+		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATION, application);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -1,5 +1,6 @@
 package com.unionmate.backend.domain.applicant.presentation;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,7 +33,8 @@ public class ApplicationController {
 	@Operation(summary = "지원서를 작성합니다.")
 	public CommonResponse<Void> submitApplication(
 		@PathVariable Long recruitmentId, @Valid @RequestBody CreateApplicantRequest createApplicantRequest) {
-		applicationUseCase.submitApplication(recruitmentId, createApplicantRequest);
+		LocalDateTime now = LocalDateTime.now();
+		applicationUseCase.submitApplication(recruitmentId, createApplicantRequest, now);
 
 		return CommonResponse.success(ApplicationResponseCode.SUBMIT_APPLICATION);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationUseCase;
@@ -37,8 +38,8 @@ public class ApplicationController {
 	@GetMapping("/{name}/{email}")
 	@Operation(summary = "자신이 작성한 지원서 목록을 조회합니다.")
 	public CommonResponse<List<GetMyApplicationsResponse>> getMyApplications(
-		@PathVariable String name, @PathVariable String email) {
-		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(name, email);
+		@RequestBody GetMyApplicationsRequest getMyApplicationsRequest) {
+		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(getMyApplicationsRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
@@ -10,7 +10,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ApplicationResponseCode implements ResponseCodeInterface {
-	SUBMIT_APPLICATION(200, HttpStatus.OK, "지원서가 성공적으로 제출되었습니다.");
+	SUBMIT_APPLICATION(200, HttpStatus.OK, "지원서가 성공적으로 제출되었습니다."),
+	GET_MY_APPLICATIONS(200, HttpStatus.OK, "본인이 작성한 지원서 목록 조회에 성공했습니다."),
+	GET_MY_APPLICATION(200, HttpStatus.OK, "본인이 작성한 지원서 조회에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
@@ -12,7 +12,8 @@ import lombok.Getter;
 public enum ApplicationResponseCode implements ResponseCodeInterface {
 	SUBMIT_APPLICATION(200, HttpStatus.OK, "지원서가 성공적으로 제출되었습니다."),
 	GET_MY_APPLICATIONS(200, HttpStatus.OK, "본인이 작성한 지원서 목록 조회에 성공했습니다."),
-	GET_MY_APPLICATION(200, HttpStatus.OK, "본인이 작성한 지원서 조회에 성공했습니다.");
+	GET_MY_APPLICATION(200, HttpStatus.OK, "본인이 작성한 지원서 조회에 성공했습니다."),
+	UPDATE_APPLICATION(200, HttpStatus.OK, "지원서가 성공적으로 수정되었습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## Related issue 🛠

- closed #22 

## 작업 내용 💻

- [x] 지원자가 작성한 지원서들의 목록을 조회하는 기능을 구현했습니다.(이름+email 입력시 해당 사용자에 맞는 지원서들이 보일 수 있도록 함.)
- [x] 지원자가 작성한 지원서를 상세조회하는 기능을 구현했습니다.
- [x] 지원자가 작성한 지원서를 수정하는 기능을 구현했습니다.(Recruitment의 endAt이 지나기 전까지만 수정할 수 있도록 함.)

## 스크린샷 📷

- 이름과 email 입력 시 작성자의 지원서 목록을 확인할 수 있도록 구현했습니다.
<img width="1403" height="663" alt="image" src="https://github.com/user-attachments/assets/807df8ee-a341-439d-b183-a51f70c8bc46" />

- 특정 지원서를 조회하는 기능을 구현했습니다. 
<img width="1414" height="754" alt="image" src="https://github.com/user-attachments/assets/81668fd1-f757-43b6-9283-3b97bad219fa" />

- 지원서를 수정하는 기능을 구현했습니다. 
<img width="1436" height="726" alt="image" src="https://github.com/user-attachments/assets/fed7dc29-ddb3-4ce0-b1c9-626896ebcc11" />
<img width="1447" height="612" alt="image" src="https://github.com/user-attachments/assets/75c2d820-a75e-485e-87f0-5f81250c03bd" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내 지원서 목록 조회 추가 — 이름·이메일로 내 지원서 확인 가능
  * 지원서 상세 조회 추가 — 텍스트/선택/날짜 답변을 포함한 상세 정보 제공
  * 지원서 수정 기능 추가 — 기본정보 및 답변을 허용 기간 내에 업데이트 가능
* **검증**
  * 수정 시 필수 항목 검증 강화 — 필수 답변 누락 시 차단
* **오류/응답**
  * 조회·단건조회·수정 관련 응답 코드 및 오류 유형 추가/명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->