### PR TITLE
Feat/#33 인터뷰 정보 설정 구현

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/SetInterviewScheduleRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/SetInterviewScheduleRequest.java
@@ -1,0 +1,15 @@
+package com.unionmate.backend.domain.applicant.application.dto.request;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SetInterviewScheduleRequest(
+	@NotNull(message = "면접 일시는 필수입니다.")
+	LocalDateTime time,
+
+	@NotBlank(message = "면접 장소는 필수입니다.")
+	String place
+) {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/InterviewScheduleUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/InterviewScheduleUseCase.java
@@ -1,0 +1,47 @@
+package com.unionmate.backend.domain.applicant.application.usecase;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.unionmate.backend.domain.applicant.application.dto.request.SetInterviewScheduleRequest;
+import com.unionmate.backend.domain.applicant.application.exception.ApplicationEvaluationForbiddenException;
+import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.applicant.domain.entity.embed.Interview;
+import com.unionmate.backend.domain.applicant.domain.service.ApplicationGetService;
+import com.unionmate.backend.domain.applicant.domain.service.ApplicationSaveService;
+import com.unionmate.backend.domain.council.domain.entity.CouncilManager;
+import com.unionmate.backend.domain.council.domain.service.CouncilManagerGetService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterviewScheduleUseCase {
+
+	private final ApplicationGetService applicationGetService;
+	private final ApplicationSaveService applicationSaveService;
+	private final CouncilManagerGetService councilManagerGetService;
+
+	@Transactional
+	public void setInterviewSchedule(Long memberId, Long applicationId, SetInterviewScheduleRequest request) {
+		Application application = applicationGetService.getApplicationById(applicationId);
+		CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(memberId);
+
+		validateSameCouncil(councilManager, application);
+
+		Interview newInterview = new Interview(request.time(), request.place());
+		application.updateInterview(newInterview);
+		applicationSaveService.save(application);
+	}
+
+	private void validateSameCouncil(CouncilManager councilManager, Application application) {
+		Long managerCouncilId = councilManager.getCouncil().getId();
+		Long applicationCouncilId = application.getRecruitment().getCouncil().getId();
+		if (!Objects.equals(managerCouncilId, applicationCouncilId)) {
+			throw new ApplicationEvaluationForbiddenException();
+		}
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/entity/Application.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/entity/Application.java
@@ -79,4 +79,8 @@ public class Application extends BaseEntity {
 	public void updateStage(Stage newStage) {
 		this.stage = newStage;
 	}
+
+	public void updateInterview(Interview newInterview) {
+		this.interview = newInterview;
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -16,6 +16,7 @@ import com.unionmate.backend.domain.applicant.application.dto.request.CreateAppl
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateCommentRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.DecisionRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.SetInterviewScheduleRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateCommentRequest;
 import com.unionmate.backend.domain.applicant.application.dto.response.CommentResponse;
@@ -24,6 +25,7 @@ import com.unionmate.backend.domain.applicant.application.dto.response.GetMyAppl
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationDecisionUseCase;
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationUseCase;
 import com.unionmate.backend.domain.applicant.application.usecase.CommentUseCase;
+import com.unionmate.backend.domain.applicant.application.usecase.InterviewScheduleUseCase;
 import com.unionmate.backend.global.auth.annotation.CurrentMemberId;
 import com.unionmate.backend.global.response.CommonResponse;
 
@@ -38,6 +40,7 @@ public class ApplicationController {
 	private final ApplicationUseCase applicationUseCase;
 	private final CommentUseCase commentUseCase;
 	private final ApplicationDecisionUseCase applicationDecisionUseCase;
+	private final InterviewScheduleUseCase interviewScheduleUseCase;
 
 	@PostMapping("/{recruitmentId}")
 	@Operation(summary = "지원서를 작성합니다.")
@@ -134,5 +137,17 @@ public class ApplicationController {
 		applicationDecisionUseCase.decideOnInterview(memberId, applicationId, decisionRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.INTERVIEW_EVALUATION_DECISION);
+	}
+
+	@PatchMapping("/{applicationId}/interview/schedule")
+	@Operation(summary = "면접 일정을 설정합니다. (관리자 전용)")
+	public CommonResponse<Void> setInterviewSchedule(
+		@CurrentMemberId Long memberId,
+		@PathVariable Long applicationId,
+		@Valid @RequestBody SetInterviewScheduleRequest setInterviewScheduleRequest
+	) {
+		interviewScheduleUseCase.setInterviewSchedule(memberId, applicationId, setInterviewScheduleRequest);
+
+		return CommonResponse.success(ApplicationResponseCode.SET_INTERVIEW_SCHEDULE);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
@@ -23,7 +23,8 @@ public enum ApplicationResponseCode implements ResponseCodeInterface {
 	UPDATE_INTERVIEW_EVALUATION(200, HttpStatus.OK, "면접 평가 코멘트가 성공적으로 수정되었습니다."),
 	DELETE_INTERVIEW_EVALUATION(200, HttpStatus.OK, "면접 평가 코멘트가 성공적으로 삭제되었습니다."),
 	DOCUMENT_DECISION(200, HttpStatus.OK, "서류 전형 결과가 성공적으로 반영되었습니다."),
-	INTERVIEW_EVALUATION_DECISION(200, HttpStatus.OK, "면접 전형 결과가 성공적으로 반영되었습니다.");
+	INTERVIEW_EVALUATION_DECISION(200, HttpStatus.OK, "면접 전형 결과가 성공적으로 반영되었습니다."),
+	SET_INTERVIEW_SCHEDULE(200, HttpStatus.OK, "면접 일정이 성공적으로 설정되었습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## Related issue 🛠

- closed #33 

## 작업 내용 💻

- [x] 인터뷰 정보 설정 구현

## 스크린샷 📷


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 면접 일정 설정: 면접 일시와 장소 정보를 입력하여 지원 현황의 면접 일정을 설정할 수 있습니다. 필수 정보에 대한 검증이 자동으로 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->