### PR TITLE
Feat #34 관리자 관련 API 구현

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationAdminResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationAdminResponse.java
@@ -1,0 +1,114 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus;
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자용 지원서 상세 응답")
+public record GetApplicationAdminResponse(
+
+	@Schema(description = "지원서 ID", example = "123")
+	Long applicationId,
+
+	@Schema(description = "모집 공고 정보")
+	RecruitmentBrief recruitment,
+
+	@Schema(description = "지원자 정보")
+	ApplicantInfo applicant,
+
+	@Schema(description = "지원 단계")
+	StageResponse stage,
+
+	@Schema(description = "면접 정보")
+	InterviewResponse interview,
+
+	@Schema(description = "문항별 답변 목록(문항 order 오름차순)")
+	List<ApplicationAnswerResponse> answers,
+
+	@Schema(description = "지원서 제출 시각", example = "2025-02-05T09:10:00")
+	LocalDateTime submittedAt
+) {
+	public static GetApplicationAdminResponse from(Application application) {
+		List<ApplicationAnswerResponse> sortedAnswers = application.getAnswers().stream()
+			.sorted(Comparator.comparing(Item::getOrder))
+			.map(ApplicationAnswerResponse::from)
+			.toList();
+
+		return new GetApplicationAdminResponse(
+			application.getId(),
+			new RecruitmentBrief(
+				application.getRecruitment().getId(),
+				application.getRecruitment().getName()
+			),
+			new ApplicantInfo(
+				application.getName(),
+				application.getEmail(),
+				application.getTel()
+			),
+			new StageResponse(
+				application.getStage().recruitmentStatus(),
+				application.getStage().evaluationStatus()
+			),
+			new InterviewResponse(
+				application.getInterview().time(),
+				application.getInterview().place()
+			),
+			sortedAnswers,
+			application.getCreatedAt()
+		);
+	}
+
+	@Schema(description = "모집 공고 요약")
+	public record RecruitmentBrief(
+
+		@Schema(description = "모집 공고 ID", example = "77")
+		Long recruitmentId,
+
+		@Schema(description = "모집 공고명", example = "리츠 1기")
+		String recruitmentName
+	) {
+	}
+
+	@Schema(description = "지원자 기본 정보")
+	public record ApplicantInfo(
+
+		@Schema(description = "이름", example = "이지훈")
+		String name,
+
+		@Schema(description = "이메일", example = "huncozyboy@example.com")
+		String email,
+
+		@Schema(description = "연락처", example = "010-1234-5678")
+		String tel
+	) {
+	}
+
+	@Schema(description = "진행 단계")
+	public record StageResponse(
+
+		@Schema(description = "리크루팅 단계", example = "DOCUMENT_SCREENING")
+		RecruitmentStatus recruitmentStatus,
+
+		@Schema(description = "평가 상태", example = "SUBMITTED")
+		EvaluationStatus evaluationStatus
+	) {
+	}
+
+	@Schema(description = "면접 정보")
+	public record InterviewResponse(
+
+		@Schema(description = "면접 일시", example = "2025-02-10T14:00:00")
+		LocalDateTime time,
+
+		@Schema(description = "면접 장소", example = "판교 플레이그라운드 5층 B-회의실")
+		String place
+	) {
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -1,15 +1,5 @@
 package com.unionmate.backend.domain.applicant.application.usecase;
 
-import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
-import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
-import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
-import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
-import com.unionmate.backend.domain.applicant.application.exception.ApplicationUpdateInvalidException;
-import com.unionmate.backend.domain.applicant.application.exception.DuplicateItemAnswerException;
-import com.unionmate.backend.domain.applicant.application.util.CalendarAnswerValidator;
-import com.unionmate.backend.domain.applicant.application.util.SelectAnswerValidator;
-import com.unionmate.backend.domain.applicant.application.util.TextAnswerValidator;
-
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,17 +16,30 @@ import org.springframework.transaction.annotation.Transactional;
 import com.unionmate.backend.domain.applicant.application.dto.request.AnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.CalendarAnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.SelectAnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.TextAnswerRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
+import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationAdminResponse;
+import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
+import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
+import com.unionmate.backend.domain.applicant.application.exception.ApplicationEvaluationForbiddenException;
+import com.unionmate.backend.domain.applicant.application.exception.ApplicationUpdateInvalidException;
+import com.unionmate.backend.domain.applicant.application.exception.DuplicateItemAnswerException;
 import com.unionmate.backend.domain.applicant.application.exception.ItemNotFoundException;
 import com.unionmate.backend.domain.applicant.application.exception.ItemTypeMismatchException;
 import com.unionmate.backend.domain.applicant.application.exception.RecruitmentInvalidException;
 import com.unionmate.backend.domain.applicant.application.exception.RequiredAnswerMissingException;
+import com.unionmate.backend.domain.applicant.application.util.CalendarAnswerValidator;
+import com.unionmate.backend.domain.applicant.application.util.SelectAnswerValidator;
+import com.unionmate.backend.domain.applicant.application.util.TextAnswerValidator;
 import com.unionmate.backend.domain.applicant.application.util.UpdateAnswerValidator;
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.applicant.domain.entity.column.Answer;
 import com.unionmate.backend.domain.applicant.domain.service.ApplicationGetService;
 import com.unionmate.backend.domain.applicant.domain.service.ApplicationSaveService;
+import com.unionmate.backend.domain.council.domain.entity.CouncilManager;
+import com.unionmate.backend.domain.council.domain.service.CouncilManagerGetService;
 import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
@@ -51,9 +54,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ApplicationUseCase {
-	private final ApplicationSaveService applicationSaveService;
+
 	private final RecruitmentGetService recruitmentGetService;
 	private final ApplicationGetService applicationGetService;
+	private final CouncilManagerGetService councilManagerGetService;
+
+	private final ApplicationSaveService applicationSaveService;
+	
 	private final TextAnswerValidator textAnswerValidator;
 	private final SelectAnswerValidator selectAnswerValidator;
 	private final CalendarAnswerValidator calendarAnswerValidator;
@@ -283,6 +290,15 @@ public class ApplicationUseCase {
 		return GetApplicationResponse.from(application);
 	}
 
+	public GetApplicationAdminResponse getApplicationForAdmin(Long memberId, Long applicationId) {
+		Application application = applicationGetService.getApplicationWithDetails(applicationId);
+
+		CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(memberId);
+		validateSameCouncil(councilManager, application);
+
+		return GetApplicationAdminResponse.from(application);
+	}
+
 	private Map<Long, Item> existingAnswers(Application application, Recruitment recruitment) {
 		Map<Long, Item> map = new HashMap<>();
 		List<Item> answers = application.getAnswers();
@@ -295,5 +311,13 @@ public class ApplicationUseCase {
 				.findFirst().ifPresent(matched -> map.put(item.getId(), matched));
 		}
 		return map;
+	}
+
+	private void validateSameCouncil(CouncilManager councilManager, Application application) {
+		Long managerCouncilId = councilManager.getCouncil().getId();
+		Long applicationCouncilId = application.getRecruitment().getCouncil().getId();
+		if (!Objects.equals(managerCouncilId, applicationCouncilId)) {
+			throw new ApplicationEvaluationForbiddenException();
+		}
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -1,7 +1,9 @@
 package com.unionmate.backend.domain.applicant.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -123,4 +125,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		order by a.id desc
 		""")
 	List<CouncilApplicantQueryRow> findInterviewListFailed(@Param("council") Council council);
+
+	@EntityGraph(attributePaths = {"recruitment", "recruitment.council", "answers"})
+	@Query("select a from Application a where a.id = :id")
+	Optional<Application> findByIdWithRecruitmentAndAnswers(@Param("id") Long id);
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
@@ -23,6 +23,11 @@ public class ApplicationGetService {
 		return applicationRepository.findAllByNameAndEmailOrderByIdDesc(name, email);
 	}
 
+	public Application getApplicationWithDetails(Long applicationId) {
+		return applicationRepository.findByIdWithRecruitmentAndAnswers(applicationId)
+			.orElseThrow(ApplicationNotFoundException::new);
+	}
+
 	public Application getApplicationById(Long applicationId) {
 		return applicationRepository.findById(applicationId)
 			.orElseThrow(ApplicationNotFoundException::new);

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -20,6 +20,7 @@ import com.unionmate.backend.domain.applicant.application.dto.request.SetIntervi
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateCommentRequest;
 import com.unionmate.backend.domain.applicant.application.dto.response.CommentResponse;
+import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationAdminResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetApplicationResponse;
 import com.unionmate.backend.domain.applicant.application.dto.response.GetMyApplicationsResponse;
 import com.unionmate.backend.domain.applicant.application.usecase.ApplicationDecisionUseCase;
@@ -69,6 +70,25 @@ public class ApplicationController {
 		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(getMyApplicationsRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);
+	}
+
+	@GetMapping("/{applicationId}/mine/admin")
+	@Operation(
+		summary = "특정 지원서를 상세 조회합니다. (관리자 전용)",
+		description = """
+			관리자 전용 단건 조회 API 입니다.
+			- 같은 학생회 소속 검증을 수행합니다.
+			- 답변 목록은 문항 order 오름차순으로 정렬됩니다.
+			- 응답에는 모집 공고/지원자/면접/스테이지/답변 정보가 모두 포함됩니다.
+			"""
+	)
+	public CommonResponse<GetApplicationAdminResponse> getApplicationForAdmin(
+		@CurrentMemberId long memberId,
+		@PathVariable long applicationId
+	) {
+		GetApplicationAdminResponse response = applicationUseCase.getApplicationForAdmin(memberId, applicationId);
+
+		return CommonResponse.success(ApplicationResponseCode.GET_APPLICATION_DETAIL_FOR_ADMIN, response);
 	}
 
 	@GetMapping("/{applicationId}")

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -72,7 +72,7 @@ public class ApplicationController {
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);
 	}
 
-	@GetMapping("/{applicationId}/mine/admin")
+	@GetMapping("/{applicationId}/detail/admin")
 	@Operation(
 		summary = "특정 지원서를 상세 조회합니다. (관리자 전용)",
 		description = """

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationResponseCode.java
@@ -13,6 +13,7 @@ public enum ApplicationResponseCode implements ResponseCodeInterface {
 	SUBMIT_APPLICATION(200, HttpStatus.OK, "지원서가 성공적으로 제출되었습니다."),
 	GET_MY_APPLICATIONS(200, HttpStatus.OK, "본인이 작성한 지원서 목록 조회에 성공했습니다."),
 	GET_MY_APPLICATION(200, HttpStatus.OK, "본인이 작성한 지원서 조회에 성공했습니다."),
+	GET_APPLICATION_DETAIL_FOR_ADMIN(200, HttpStatus.OK, "관리자용 지원서 상세 조회에 성공했습니다."),
 	UPDATE_APPLICATION(200, HttpStatus.OK, "지원서가 성공적으로 수정되었습니다."),
 	CREATE_COMMENT(200, HttpStatus.OK, "지원서 코멘트가 성공적으로 생성되었습니다."),
 	UPDATE_COMMENT(200, HttpStatus.OK, "지원서 코멘트가 성공적으로 수정되었습니다."),

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/ToggleRecruitmentActivationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/ToggleRecruitmentActivationRequest.java
@@ -2,10 +2,10 @@ package com.unionmate.backend.domain.recruitment.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "모집 게시 토글 요청(OFF→ON만 허용). active=false 요청은 거부됩니다.")
+@Schema(description = "모집 게시 상태 토글 요청(ON/OFF 모두 허용)")
 public record ToggleRecruitmentActivationRequest(
 
-	@Schema(description = "활성화 여부. true만 허용됩니다.", example = "true")
+	@Schema(description = "활성화 여부 (모집 게시 여부)", example = "true")
 	boolean active
 ) {
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/ToggleRecruitmentActivationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/ToggleRecruitmentActivationRequest.java
@@ -8,7 +8,4 @@ public record ToggleRecruitmentActivationRequest(
 	@Schema(description = "활성화 여부. true만 허용됩니다.", example = "true")
 	boolean active
 ) {
-	public static ToggleRecruitmentActivationRequest of(boolean active) {
-		return new ToggleRecruitmentActivationRequest(active);
-	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/ToggleRecruitmentActivationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/ToggleRecruitmentActivationRequest.java
@@ -1,0 +1,14 @@
+package com.unionmate.backend.domain.recruitment.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "모집 게시 토글 요청(OFF→ON만 허용). active=false 요청은 거부됩니다.")
+public record ToggleRecruitmentActivationRequest(
+
+	@Schema(description = "활성화 여부. true만 허용됩니다.", example = "true")
+	boolean active
+) {
+	public static ToggleRecruitmentActivationRequest of(boolean active) {
+		return new ToggleRecruitmentActivationRequest(active);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/ToggleRecruitmentActivationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/ToggleRecruitmentActivationResponse.java
@@ -1,0 +1,30 @@
+package com.unionmate.backend.domain.recruitment.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "모집 게시 토글 응답")
+public record ToggleRecruitmentActivationResponse(
+
+	@Schema(description = "모집 ID", example = "101")
+	Long recruitmentId,
+
+	@Schema(description = "현재 활성화 여부", example = "true")
+	boolean active,
+
+	@Schema(description = "현재 시각 기준 모집 가능 여부(isActive && 기간 내)", example = "true")
+	boolean open,
+
+	@Schema(description = "모집 시작 시각")
+	LocalDateTime startAt,
+
+	@Schema(description = "모집 종료 시각")
+	LocalDateTime endAt
+) {
+	public static ToggleRecruitmentActivationResponse of(
+		Long recruitmentId, boolean active, boolean open, LocalDateTime startAt, LocalDateTime endAt
+	) {
+		return new ToggleRecruitmentActivationResponse(recruitmentId, active, open, startAt, endAt);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/ToggleRecruitmentActivationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/ToggleRecruitmentActivationResponse.java
@@ -13,7 +13,7 @@ public record ToggleRecruitmentActivationResponse(
 	@Schema(description = "현재 활성화 여부", example = "true")
 	boolean active,
 
-	@Schema(description = "현재 시각 기준 모집 가능 여부(isActive && 기간 내)", example = "true")
+	@Schema(description = "모집 시간 내부에 공개 했는지 여부 (startAt ~ endAt)", example = "true")
 	boolean open,
 
 	@Schema(description = "모집 시작 시각")

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/ErrorCode.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/ErrorCode.java
@@ -10,7 +10,10 @@ import lombok.Getter;
 public enum ErrorCode implements ErrorInfo {
 	RECRUITMENT_FORM_NOT_FOUND("해당 지원서 양식을 찾을 수 없습니다.", 2100),
 	ITEM_TYPE_NOT_EXIST("해당 종류의 항목은 존재하지 않습니다.", 2101),
-	NOT_RECRUITMENT_COUNCIL_MEMBER("해당 지원서 양식과 관련된 학생회 멤버가 아닙니다.", 2102);
+	NOT_RECRUITMENT_COUNCIL_MEMBER("해당 지원서 양식과 관련된 학생회 멤버가 아닙니다.", 2102),
+	RECRUITMENT_ACTIVATION_INVALID_PERIOD("모집 게시를 활성화할 수 없는 기간입니다.", 2103),
+	RECRUITMENT_DEACTIVATION_NOT_ALLOWED("모집 게시 비활성화는 허용되지 않습니다.", 2104),
+	RECRUITMENT_ACTIVATION_EXPIRED("모집 게시 활성화 기간이 만료되었습니다.", 2105);
 
 	private final String message;
 	private final Integer code;

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/RecruitmentActivationExpiredException.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/RecruitmentActivationExpiredException.java
@@ -1,0 +1,11 @@
+package com.unionmate.backend.domain.recruitment.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.unionmate.backend.exception.ApplicationException;
+
+public class RecruitmentActivationExpiredException extends ApplicationException {
+	public RecruitmentActivationExpiredException() {
+		super(ErrorCode.RECRUITMENT_ACTIVATION_EXPIRED, HttpStatus.BAD_REQUEST);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/RecruitmentActivationInvalidPeriodException.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/RecruitmentActivationInvalidPeriodException.java
@@ -1,0 +1,11 @@
+package com.unionmate.backend.domain.recruitment.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.unionmate.backend.exception.ApplicationException;
+
+public class RecruitmentActivationInvalidPeriodException extends ApplicationException {
+	public RecruitmentActivationInvalidPeriodException() {
+		super(ErrorCode.RECRUITMENT_ACTIVATION_INVALID_PERIOD, HttpStatus.BAD_REQUEST);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/RecruitmentDeactivationNotAllowedException.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/exception/RecruitmentDeactivationNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.unionmate.backend.domain.recruitment.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.unionmate.backend.exception.ApplicationException;
+
+public class RecruitmentDeactivationNotAllowedException extends ApplicationException {
+	public RecruitmentDeactivationNotAllowedException() {
+		super(ErrorCode.RECRUITMENT_DEACTIVATION_NOT_ALLOWED, HttpStatus.BAD_REQUEST);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
@@ -60,7 +60,9 @@ public class RecruitmentUseCase {
 	}
 
 	@Transactional
-	public ToggleRecruitmentActivationResponse toggleRecruitmentActivation(Long memberId, Long recruitmentId,
+	public ToggleRecruitmentActivationResponse toggleRecruitmentActivation(
+		Long memberId,
+		Long recruitmentId,
 		ToggleRecruitmentActivationRequest toggleRecruitmentActivationRequest,
 		LocalDateTime now
 	) {
@@ -69,9 +71,9 @@ public class RecruitmentUseCase {
 
 		validateSameCouncil(councilManager, recruitment);
 
-		recruitmentUpdateService.activateIfAllowed(recruitment, toggleRecruitmentActivationRequest.active(), now);
-		boolean open = recruitment.isOpen(now);
+		recruitmentUpdateService.changeActivation(recruitment, toggleRecruitmentActivationRequest.active(), now);
 
+		boolean open = recruitment.isOpen(now);
 		return ToggleRecruitmentActivationResponse.of(
 			recruitment.getId(),
 			Boolean.TRUE.equals(recruitment.getIsActive()),

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
@@ -9,13 +9,14 @@ import org.springframework.transaction.annotation.Transactional;
 import com.unionmate.backend.domain.council.domain.entity.Council;
 import com.unionmate.backend.domain.council.domain.entity.CouncilManager;
 import com.unionmate.backend.domain.council.domain.service.CouncilManagerGetService;
-import com.unionmate.backend.domain.council.exception.CouncilManagerNotFoundException;
+import com.unionmate.backend.domain.council.exception.DifferentCouncilException;
 import com.unionmate.backend.domain.recruitment.application.dto.request.CreateItemRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.request.CreateRecruitmentRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.request.SelectOptionRequest;
+import com.unionmate.backend.domain.recruitment.application.dto.request.ToggleRecruitmentActivationRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.response.ItemResponse;
 import com.unionmate.backend.domain.recruitment.application.dto.response.RecruitmentResponse;
-import com.unionmate.backend.domain.recruitment.application.exception.NotRecruitmentCouncilMemberException;
+import com.unionmate.backend.domain.recruitment.application.dto.response.ToggleRecruitmentActivationResponse;
 import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.AnnouncementItem;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
@@ -25,15 +26,19 @@ import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItemOpt
 import com.unionmate.backend.domain.recruitment.domain.entity.item.TextItem;
 import com.unionmate.backend.domain.recruitment.domain.service.RecruitmentGetService;
 import com.unionmate.backend.domain.recruitment.domain.service.RecruitmentSaveService;
+import com.unionmate.backend.domain.recruitment.domain.service.RecruitmentUpdateService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitmentUseCase {
+
 	private final CouncilManagerGetService councilManagerGetService;
-	private final RecruitmentSaveService recruitmentSaveService;
 	private final RecruitmentGetService recruitmentGetService;
+
+	private final RecruitmentSaveService recruitmentSaveService;
+	private final RecruitmentUpdateService recruitmentUpdateService;
 
 	@Transactional
 	public void createRecruitment(Long memberId, CreateRecruitmentRequest createRecruitmentRequest) {
@@ -52,6 +57,28 @@ public class RecruitmentUseCase {
 			}
 		}
 		recruitmentSaveService.save(recruitment);
+	}
+
+	@Transactional
+	public ToggleRecruitmentActivationResponse toggleRecruitmentActivation(Long memberId, Long recruitmentId,
+		ToggleRecruitmentActivationRequest toggleRecruitmentActivationRequest,
+		LocalDateTime now
+	) {
+		Recruitment recruitment = recruitmentGetService.getRecruitmentById(recruitmentId);
+		CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(memberId);
+
+		validateSameCouncil(councilManager, recruitment);
+
+		recruitmentUpdateService.activateIfAllowed(recruitment, toggleRecruitmentActivationRequest.active(), now);
+		boolean open = recruitment.isOpen(now);
+
+		return ToggleRecruitmentActivationResponse.of(
+			recruitment.getId(),
+			Boolean.TRUE.equals(recruitment.getIsActive()),
+			open,
+			recruitment.getStartAt(),
+			recruitment.getEndAt()
+		);
 	}
 
 	public RecruitmentResponse getRecruitmentForm(Long id) {
@@ -93,5 +120,14 @@ public class RecruitmentUseCase {
 				AnnouncementItem.createRecruitmentAnnouncement(recruitment, required, createItemRequest.title(),
 					createItemRequest.order(), createItemRequest.description(), createItemRequest.announcement());
 		};
+	}
+
+	private void validateSameCouncil(CouncilManager councilManager, Recruitment recruitment) {
+		Long managerCouncilId = councilManager.getCouncil().getId();
+		Long recruitmentCouncilId = recruitment.getCouncil().getId();
+		if (!managerCouncilId.equals(recruitmentCouncilId)) {
+
+			throw new DifferentCouncilException();
+		}
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/Recruitment.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/Recruitment.java
@@ -60,12 +60,6 @@ public class Recruitment extends BaseEntity {
 	@Builder.Default
 	private List<Item> items = new ArrayList<>();
 
-	public boolean isOpen(LocalDateTime now) {
-		return Boolean.TRUE.equals(isActive)
-			&& !now.isBefore(startAt)
-			&& !now.isAfter(endAt);
-	}
-
 	public static Recruitment createRecruitment(Council council, String name, LocalDateTime startAt,
 		LocalDateTime endAt, Boolean isActive, RecruitmentStatus recruitmentStatus) {
 		return Recruitment.builder()
@@ -76,5 +70,19 @@ public class Recruitment extends BaseEntity {
 			.isActive(isActive)
 			.recruitmentStatus(recruitmentStatus)
 			.build();
+	}
+
+	public void updateActivation(boolean active) {
+		this.isActive = active;
+	}
+
+	public boolean isOpen(LocalDateTime now) {
+		return Boolean.TRUE.equals(isActive)
+			&& !now.isBefore(startAt)
+			&& !now.isAfter(endAt);
+	}
+
+	public boolean isOpenForActivation(LocalDateTime now) {
+		return !now.isBefore(startAt);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/Recruitment.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/Recruitment.java
@@ -3,6 +3,7 @@ package com.unionmate.backend.domain.recruitment.domain.entity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.unionmate.backend.domain.council.domain.entity.Council;
 import com.unionmate.backend.domain.recruitment.application.exception.RecruitmentActivationExpiredException;
@@ -83,22 +84,12 @@ public class Recruitment extends BaseEntity {
 			&& !now.isAfter(endAt);
 	}
 
-	public boolean isOpenForActivation(LocalDateTime now) {
-		return !now.isBefore(startAt);
-	}
-
-	public void activateIfAllowed(LocalDateTime now, boolean requestedActive) {
-		if (!requestedActive)
-			return;
-
-		if (now.isAfter(endAt))
+	public void changeActivation(LocalDateTime now, boolean requestedActive) {
+		if (requestedActive && now.isAfter(endAt)) {
 			throw new RecruitmentActivationExpiredException();
-
-		if (!isOpenForActivation(now))
-			return;
-
-		if (!Boolean.TRUE.equals(this.isActive)) {
-			updateActivation(true);
+		}
+		if (!Objects.equals(this.isActive, requestedActive)) {
+			updateActivation(requestedActive);
 		}
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/Recruitment.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/Recruitment.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.unionmate.backend.domain.council.domain.entity.Council;
+import com.unionmate.backend.domain.recruitment.application.exception.RecruitmentActivationExpiredException;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
 import com.unionmate.backend.global.entity.BaseEntity;
@@ -84,5 +85,20 @@ public class Recruitment extends BaseEntity {
 
 	public boolean isOpenForActivation(LocalDateTime now) {
 		return !now.isBefore(startAt);
+	}
+
+	public void activateIfAllowed(LocalDateTime now, boolean requestedActive) {
+		if (!requestedActive)
+			return;
+
+		if (now.isAfter(endAt))
+			throw new RecruitmentActivationExpiredException();
+
+		if (!isOpenForActivation(now))
+			return;
+
+		if (!Boolean.TRUE.equals(this.isActive)) {
+			updateActivation(true);
+		}
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentUpdateService.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentUpdateService.java
@@ -16,11 +16,11 @@ public class RecruitmentUpdateService {
 	private final RecruitmentSaveService recruitmentSaveService;
 
 	@Transactional
-	public void activateIfAllowed(Recruitment recruitment, boolean requestedActive, LocalDateTime now) {
+	public void changeActivation(Recruitment recruitment, boolean requestedActive, LocalDateTime now) {
 		boolean before = Boolean.TRUE.equals(recruitment.getIsActive());
-		recruitment.activateIfAllowed(now, requestedActive);
-		boolean after = Boolean.TRUE.equals(recruitment.getIsActive());
+		recruitment.changeActivation(now, requestedActive);
 
+		boolean after = Boolean.TRUE.equals(recruitment.getIsActive());
 		if (after != before) {
 			recruitmentSaveService.save(recruitment);
 		}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentUpdateService.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentUpdateService.java
@@ -1,0 +1,28 @@
+package com.unionmate.backend.domain.recruitment.domain.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentUpdateService {
+
+	private final RecruitmentSaveService recruitmentSaveService;
+
+	@Transactional
+	public void activateIfAllowed(Recruitment recruitment, boolean requestedActive, LocalDateTime now) {
+		boolean before = Boolean.TRUE.equals(recruitment.getIsActive());
+		recruitment.activateIfAllowed(now, requestedActive);
+		boolean after = Boolean.TRUE.equals(recruitment.getIsActive());
+
+		if (after != before) {
+			recruitmentSaveService.save(recruitment);
+		}
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
@@ -52,7 +52,7 @@ public class RecruitmentController {
 			- 한번 게시하면 비활성화(ON→OFF)는 불가함
 			- 요청 본문의 active는 true만 허용됨(필수)
 			- active=true는 endAt 기간 이후에는 허용되지 않음
-			- 응답의 open은 isActive && 기간충족을 의미함
+			- 응답의 open은 isActive && 기간충족을 의미함 (함께 반환해주는 이유는 startAt 이전에도 미리 게시를 활성화할 수 있기 때문)
 			"""
 	)
 	public CommonResponse<ToggleRecruitmentActivationResponse> toggleRecruitmentActivation(

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
@@ -49,8 +49,6 @@ public class RecruitmentController {
 	@Operation(
 		summary = "학생회 모집을 게시합니다. (OFF→ON) (관리자 전용)",
 		description = """
-			- 한번 게시하면 비활성화(ON→OFF)는 불가함
-			- 요청 본문의 active는 true만 허용됨(필수)
 			- active=true는 endAt 기간 이후에는 허용되지 않음
 			- 응답의 open은 isActive && 기간충족을 의미함 (함께 반환해주는 이유는 startAt 이전에도 미리 게시를 활성화할 수 있기 때문)
 			"""

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
@@ -1,5 +1,7 @@
 package com.unionmate.backend.domain.recruitment.presentation;
 
+import java.time.LocalDateTime;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,7 +10,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.unionmate.backend.domain.recruitment.application.dto.request.CreateRecruitmentRequest;
+import com.unionmate.backend.domain.recruitment.application.dto.request.ToggleRecruitmentActivationRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.response.RecruitmentResponse;
+import com.unionmate.backend.domain.recruitment.application.dto.response.ToggleRecruitmentActivationResponse;
 import com.unionmate.backend.domain.recruitment.application.usecase.RecruitmentUseCase;
 import com.unionmate.backend.global.auth.annotation.CurrentMemberId;
 import com.unionmate.backend.global.response.CommonResponse;
@@ -39,5 +43,28 @@ public class RecruitmentController {
 		RecruitmentResponse recruitmentResponse = recruitmentUseCase.getRecruitmentForm(recruitmentId);
 
 		return CommonResponse.success(RecruitmentResponseCode.GET_RECRUITMENT, recruitmentResponse);
+	}
+
+	@PostMapping("/{recruitmentId}/activation")
+	@Operation(
+		summary = "학생회 모집을 게시합니다. (OFF→ON) (관리자 전용)",
+		description = """
+			- 한번 게시하면 비활성화(ON→OFF)는 불가함
+			- 요청 본문의 active는 true만 허용됨(필수)
+			- active=true는 endAt 기간 이후에는 허용되지 않음
+			- 응답의 open은 isActive && 기간충족을 의미함
+			"""
+	)
+	public CommonResponse<ToggleRecruitmentActivationResponse> toggleRecruitmentActivation(
+		@CurrentMemberId Long memberId,
+		@PathVariable Long recruitmentId,
+		@Valid @RequestBody ToggleRecruitmentActivationRequest toggleRecruitmentActivationRequest
+	) {
+		LocalDateTime now = LocalDateTime.now();
+		ToggleRecruitmentActivationResponse response = recruitmentUseCase.toggleRecruitmentActivation(
+			memberId, recruitmentId, toggleRecruitmentActivationRequest, now
+		);
+
+		return CommonResponse.success(RecruitmentResponseCode.RECRUITMENT_TOGGLE_ACTIVATION, response);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentResponseCode.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentResponseCode.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RecruitmentResponseCode implements ResponseCodeInterface {
 	CREATE_RECRUITMENT(200, HttpStatus.OK, "지원서 양식 생성에 성공했습니다."),
-	GET_RECRUITMENT(200, HttpStatus.OK, "지원서 양식 조회에 성공했습니다.");
+	GET_RECRUITMENT(200, HttpStatus.OK, "지원서 양식 조회에 성공했습니다."),
+	RECRUITMENT_TOGGLE_ACTIVATION(200, HttpStatus.OK, "학생회 모집 게시 상태 변경에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## Related issue 🛠

- closed #34 

## 작업 내용 💻

- [x] 모집게시 상태변경 API
특정 지원을 현재 지원받을 수 있는 상태로 변경하는 토글에 사용할 API

<img width="315" height="144" alt="Image" src="https://github.com/user-attachments/assets/0a8d84e4-3c58-4f08-b3c9-57e2f8c33770" />

<img width="268" height="138" alt="Image" src="https://github.com/user-attachments/assets/5d3fe78f-b383-411c-99d9-60847c426aa4" />

- [x] 관리자 지원서 상세 조회 API
서류 평가 전 뎁스로, 관리자가 지원서를 단건으로 조회할 수 있는 API

<img width="1457" height="788" alt="Image" src="https://github.com/user-attachments/assets/481e4f39-5fc3-4478-b633-e7b72df8f591" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- `RecruitmentActivationExpiredException`: `endAt` 이후 활성화 시도 시는 예외처리 해주었고, 기획 요구사항에 맞춰,
`startAt` 이전에도 게시하여 홍보가 가능하도록 설계해주었습니다.
또한 반환시 `boolean`으로 `open`값을 함께 보내주어 `startAt`과 `endAt` 사이에 기간 내부인지 함께 조회해주어, 
클라단에서 구별할 수 있도록 하였습니다 

- 관리자용 지원서 상세 응답은 한 페이지의 필드가 많아서 `GetApplicationAdminResponse`이라는 큰 레코드안에
세부 레코드들을 캡슐화하여 넣어줬는데, 누락된 필드들이 혹시 있는지 꼼꼼히 봐주시면 좋을거같아요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자용 지원서 상세 조회 추가 — 지원자 정보·모집 요약·면접 일정·답변 일괄 제공
  * 모집 공고 게시 상태 토글 추가 — 활성화/비활성화 및 공개 여부 확인 가능 (관리자 전용 엔드포인트)

* **개선 사항**
  * 동일 학생회 검증 추가로 관리자 조회 권한 강화
  * 모집 기간 만료 관련 오류 처리(활성화 제한) 및 관련 오류 코드/예외 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->