### PR TITLE
refactor: 로그인 시 반환값에 councilId 추가

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/auth/application/dto/response/ManagerLoginResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/auth/application/dto/response/ManagerLoginResponse.java
@@ -1,11 +1,12 @@
 package com.unionmate.backend.domain.auth.application.dto.response;
 
 public record ManagerLoginResponse(
-    String accessToken,
-    String refreshToken
+	String accessToken,
+	String refreshToken,
+	Long councilId
 ) {
 
-  public static ManagerLoginResponse of(String accessToken, String refreshToken) {
-    return new ManagerLoginResponse(accessToken, refreshToken);
-  }
+	public static ManagerLoginResponse of(String accessToken, String refreshToken, Long councilId) {
+		return new ManagerLoginResponse(accessToken, refreshToken, councilId);
+	}
 }

--- a/src/main/java/com/unionmate/backend/domain/auth/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/auth/application/usecase/AuthUseCase.java
@@ -67,7 +67,7 @@ public class AuthUseCase {
 		Long councilId = null;
 		if (councilManagerGetService.existsByMember(member)) {
 			CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(member.getId());
-			councilId = councilManager.getId();
+			councilId = councilManager.getCouncil().getId();
 		}
 
 		return ManagerLoginResponse.of(accessToken, refreshToken, councilId);

--- a/src/main/java/com/unionmate/backend/domain/auth/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/auth/application/usecase/AuthUseCase.java
@@ -8,11 +8,15 @@ import com.unionmate.backend.domain.auth.application.dto.response.ReissueRespons
 import com.unionmate.backend.domain.auth.domain.service.AuthService;
 import com.unionmate.backend.domain.auth.exception.EmailDuplicateException;
 import com.unionmate.backend.domain.auth.exception.PasswordNotMatchException;
+import com.unionmate.backend.domain.council.domain.entity.CouncilManager;
+import com.unionmate.backend.domain.council.domain.service.CouncilManagerGetService;
 import com.unionmate.backend.domain.member.domain.entity.Member;
 import com.unionmate.backend.domain.member.domain.service.MemberGetService;
 import com.unionmate.backend.domain.member.domain.service.MemberSaveService;
 import com.unionmate.backend.global.util.jwt.JwtProvider;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,54 +24,61 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthUseCase {
 
-  private final AuthService authService;
-  private final MemberGetService memberGetService;
-  private final MemberSaveService memberSaveService;
-  private final JwtProvider jwtProvider;
+	private final AuthService authService;
+	private final MemberGetService memberGetService;
+	private final MemberSaveService memberSaveService;
+	private final CouncilManagerGetService councilManagerGetService;
+	private final JwtProvider jwtProvider;
 
-  @Transactional
-  public ManagerRegisterResponse managerRegister(ManagerRegisterRequest managerRegisterRequest) {
-    if (this.memberGetService.existsByEmail(managerRegisterRequest.email())) {
-      throw new EmailDuplicateException();
-    }
+	@Transactional
+	public ManagerRegisterResponse managerRegister(ManagerRegisterRequest managerRegisterRequest) {
+		if (this.memberGetService.existsByEmail(managerRegisterRequest.email())) {
+			throw new EmailDuplicateException();
+		}
 
-    // TODO: 학교 이메일 인증
+		// TODO: 학교 이메일 인증
 
-    String encodePassword = this.authService.encodePassword(managerRegisterRequest.password());
+		String encodePassword = this.authService.encodePassword(managerRegisterRequest.password());
 
-    Member member = Member.builder()
-        .name(managerRegisterRequest.name())
-        .email(managerRegisterRequest.email())
-        .password(encodePassword)
-        .build();
+		Member member = Member.builder()
+			.name(managerRegisterRequest.name())
+			.email(managerRegisterRequest.email())
+			.password(encodePassword)
+			.build();
 
-    Member persisted = this.memberSaveService.save(member);
+		Member persisted = this.memberSaveService.save(member);
 
-    String accessToken = this.jwtProvider.generateAccessToken(persisted);
-    String refreshToken = this.jwtProvider.generateRefreshToken(persisted.getId());
+		String accessToken = this.jwtProvider.generateAccessToken(persisted);
+		String refreshToken = this.jwtProvider.generateRefreshToken(persisted.getId());
 
-    return ManagerRegisterResponse.of(accessToken, refreshToken);
-  }
+		return ManagerRegisterResponse.of(accessToken, refreshToken);
+	}
 
-  public ManagerLoginResponse managerLogin(ManagerLoginRequest managerLoginRequest) {
-    Member member = this.memberGetService.getMemberByEmail(managerLoginRequest.email());
+	public ManagerLoginResponse managerLogin(ManagerLoginRequest managerLoginRequest) {
+		Member member = this.memberGetService.getMemberByEmail(managerLoginRequest.email());
 
-    if (!this.authService.isValidPassword(managerLoginRequest.password(), member.getPassword())) {
-      throw new PasswordNotMatchException();
-    }
+		if (!this.authService.isValidPassword(managerLoginRequest.password(), member.getPassword())) {
+			throw new PasswordNotMatchException();
+		}
 
-    String accessToken = this.jwtProvider.generateAccessToken(member);
-    String refreshToken = this.jwtProvider.generateRefreshToken(member.getId());
+		String accessToken = this.jwtProvider.generateAccessToken(member);
+		String refreshToken = this.jwtProvider.generateRefreshToken(member.getId());
 
-    return ManagerLoginResponse.of(accessToken, refreshToken);
-  }
+		Long councilId = null;
+		if (councilManagerGetService.existsByMember(member)) {
+			CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(member.getId());
+			councilId = councilManager.getId();
+		}
 
-  public ReissueResponse reissue(Long memberId) {
-    Member member = this.memberGetService.getMemberById(memberId);
+		return ManagerLoginResponse.of(accessToken, refreshToken, councilId);
+	}
 
-    String accessToken = this.jwtProvider.generateAccessToken(member);
-    String refreshToken = this.jwtProvider.generateRefreshToken(member.getId());
+	public ReissueResponse reissue(Long memberId) {
+		Member member = this.memberGetService.getMemberById(memberId);
 
-    return ReissueResponse.of(accessToken, refreshToken);
-  }
+		String accessToken = this.jwtProvider.generateAccessToken(member);
+		String refreshToken = this.jwtProvider.generateRefreshToken(member.getId());
+
+		return ReissueResponse.of(accessToken, refreshToken);
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #41 
## 작업 내용 💻

- [x] 로그인 시 반환값에 councilId가 추가되도록 수정했습니다. 
만약 학생회가 가입되어있지 않으면 null값이 반환됩니다.

## 스크린샷 📷

<img width="1469" height="351" alt="image" src="https://github.com/user-attachments/assets/4a67f410-cd18-4bc1-bf41-a0492e239473" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 매니저 로그인 응답에 협의회 ID(councilId)가 포함되어 반환됩니다.

* **개선 사항**
  * 매니저 등록 흐름이 개선되어 등록 안정성과 처리 흐름이 향상되었습니다.
  * 매니저 로그인 시 해당되는 경우 협의회 정보를 함께 반영하여 응답합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->