### PR TITLE
Feat/#43 지원서 양식 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/GetRecruitmentsResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/GetRecruitmentsResponse.java
@@ -1,0 +1,24 @@
+package com.unionmate.backend.domain.recruitment.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
+
+public record GetRecruitmentsResponse(
+	Long id,
+	String name,
+	Boolean isActive,
+	RecruitmentStatus recruitmentStatus,
+	boolean isOpen
+) {
+	public static GetRecruitmentsResponse from(Recruitment recruitment, LocalDateTime now) {
+		return new GetRecruitmentsResponse(
+			recruitment.getId(),
+			recruitment.getName(),
+			recruitment.getIsActive(),
+			recruitment.getRecruitmentStatus(),
+			recruitment.isOpen(now)
+		);
+	}
+}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/GetRecruitmentsResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/GetRecruitmentsResponse.java
@@ -9,16 +9,14 @@ public record GetRecruitmentsResponse(
 	Long id,
 	String name,
 	Boolean isActive,
-	RecruitmentStatus recruitmentStatus,
-	boolean isOpen
+	RecruitmentStatus recruitmentStatus
 ) {
-	public static GetRecruitmentsResponse from(Recruitment recruitment, LocalDateTime now) {
+	public static GetRecruitmentsResponse from(Recruitment recruitment) {
 		return new GetRecruitmentsResponse(
 			recruitment.getId(),
 			recruitment.getName(),
 			recruitment.getIsActive(),
-			recruitment.getRecruitmentStatus(),
-			recruitment.isOpen(now)
+			recruitment.getRecruitmentStatus()
 		);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/GetRecruitmentsResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/GetRecruitmentsResponse.java
@@ -1,7 +1,5 @@
 package com.unionmate.backend.domain.recruitment.application.dto.response;
 
-import java.time.LocalDateTime;
-
 import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
 

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
@@ -28,6 +28,7 @@ import com.unionmate.backend.domain.recruitment.application.dto.request.UpdateRe
 import com.unionmate.backend.domain.recruitment.application.dto.request.UpdateSelectOptionRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.request.UpdateSelectRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.request.UpdateTextRequest;
+import com.unionmate.backend.domain.recruitment.application.dto.response.GetRecruitmentsResponse;
 import com.unionmate.backend.domain.recruitment.application.dto.response.ItemResponse;
 import com.unionmate.backend.domain.recruitment.application.dto.response.RecruitmentResponse;
 import com.unionmate.backend.domain.recruitment.application.dto.response.ToggleRecruitmentActivationResponse;
@@ -57,7 +58,7 @@ public class RecruitmentUseCase {
 	private final RecruitmentGetService recruitmentGetService;
 	private final RecruitmentFormUpdateService recruitmentFormUpdateService;
 	private final RecruitmentDeleteService recruitmentDeleteService;
-	private final ApplicationGetService  applicationGetService;
+	private final ApplicationGetService applicationGetService;
 
 	private final RecruitmentSaveService recruitmentSaveService;
 	private final RecruitmentUpdateService recruitmentUpdateService;
@@ -151,6 +152,13 @@ public class RecruitmentUseCase {
 		}
 
 		recruitmentDeleteService.deleteRecruitment(recruitmentId);
+	}
+
+	public List<GetRecruitmentsResponse> getRecruitments(Long memberId) {
+		CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(memberId);
+		Council council = councilManager.getCouncil();
+
+		return recruitmentGetService.getRecruitments(council.getId());
 	}
 
 	public RecruitmentResponse getRecruitmentForm(Long recruitmentId) {

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/repository/RecruitmentRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/repository/RecruitmentRepository.java
@@ -1,5 +1,6 @@
 package com.unionmate.backend.domain.recruitment.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
 		where r.id = :id
 		""")
 	Optional<Recruitment> findFormById(@Param("id") Long id);
+
+	List<Recruitment> findAllByCouncilIdOrderByCreatedAtDesc(Long councilId);
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentGetService.java
@@ -1,7 +1,10 @@
 package com.unionmate.backend.domain.recruitment.domain.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.unionmate.backend.domain.recruitment.application.dto.response.GetRecruitmentsResponse;
 import com.unionmate.backend.domain.recruitment.application.exception.RecruitmentNotFoundException;
 import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.repository.RecruitmentRepository;
@@ -16,5 +19,11 @@ public class RecruitmentGetService {
 	public Recruitment getRecruitmentById(Long id) {
 		return recruitmentRepository.findFormById(id)
 			.orElseThrow(RecruitmentNotFoundException::new);
+	}
+
+	public List<GetRecruitmentsResponse> getRecruitments(Long councilId) {
+		return recruitmentRepository.findAllByCouncilIdOrderByCreatedAtDesc(councilId).stream()
+			.map(GetRecruitmentsResponse::from)
+			.toList();
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
@@ -63,7 +63,7 @@ public class RecruitmentController {
 	}
 
 	@GetMapping
-	@Operation(summary = "학생회가 작성한 지원서 양식 전체를 조회합니다.")
+	@Operation(summary = "학생회가 작성한 지원서 양식 목록을 조회합니다.")
 	public CommonResponse<List<GetRecruitmentsResponse>> getRecruitments(@CurrentMemberId Long memberId) {
 		List<GetRecruitmentsResponse> getRecruitmentsResponses = recruitmentUseCase.getRecruitments(memberId);
 

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentController.java
@@ -1,7 +1,9 @@
 package com.unionmate.backend.domain.recruitment.presentation;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.unionmate.backend.domain.recruitment.application.dto.request.CreateRecruitmentRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.request.ToggleRecruitmentActivationRequest;
 import com.unionmate.backend.domain.recruitment.application.dto.request.UpdateRecruitmentRequest;
+import com.unionmate.backend.domain.recruitment.application.dto.response.GetRecruitmentsResponse;
 import com.unionmate.backend.domain.recruitment.application.dto.response.RecruitmentResponse;
 import com.unionmate.backend.domain.recruitment.application.dto.response.ToggleRecruitmentActivationResponse;
 import com.unionmate.backend.domain.recruitment.application.usecase.RecruitmentUseCase;
@@ -57,6 +60,14 @@ public class RecruitmentController {
 		recruitmentUseCase.deleteRecruitment(memberId, recruitmentId);
 
 		return CommonResponse.success(RecruitmentResponseCode.DELETE_RECRUITMENT);
+	}
+
+	@GetMapping
+	@Operation(summary = "학생회가 작성한 지원서 양식 전체를 조회합니다.")
+	public CommonResponse<List<GetRecruitmentsResponse>> getRecruitments(@CurrentMemberId Long memberId) {
+		List<GetRecruitmentsResponse> getRecruitmentsResponses = recruitmentUseCase.getRecruitments(memberId);
+
+		return CommonResponse.success(RecruitmentResponseCode.GET_RECRUITMENTS, getRecruitmentsResponses);
 	}
 
 	@GetMapping("/{recruitmentId}")

--- a/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentResponseCode.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/presentation/RecruitmentResponseCode.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public enum RecruitmentResponseCode implements ResponseCodeInterface {
 	CREATE_RECRUITMENT(200, HttpStatus.OK, "지원서 양식 생성에 성공했습니다."),
 	UPDATE_RECRUITMENT(200, HttpStatus.OK, "지원서 양식 수정에 성공했습니다."),
+	GET_RECRUITMENTS(200, HttpStatus.OK, "지원서 양식 목록 조회에 성공했습니다."),
 	GET_RECRUITMENT(200, HttpStatus.OK, "지원서 양식 조회에 성공했습니다."),
 	DELETE_RECRUITMENT(200, HttpStatus.OK, "지원서 삭제에 성공했습니다."),
 	RECRUITMENT_TOGGLE_ACTIVATION(200, HttpStatus.OK, "학생회 모집 게시 상태 변경에 성공했습니다.");

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8000
 spring:
   application:
     name: backend-service

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8000
+  port: 8080
 spring:
   application:
     name: backend-service


### PR DESCRIPTION
## Related issue 🛠

- closed #43 

## 작업 내용 💻

- [x] 현재 로그인한 사용자가 속한 학생회에서 작성한 지원서 양식의 목록을 조회하는 기능을 구현했습니다. 

## 스크린샷 📷
<img width="1536" height="487" alt="image" src="https://github.com/user-attachments/assets/6d39a263-20d5-4450-a4fa-dfee48b8a1ec" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지원서 양식 목록 조회 기능 추가
    * 최신 생성순으로 정렬된 지원서 목록을 조회할 수 있습니다.
    * 각 항목에서 ID, 이름, 활성 여부(isActive), 모집 상태 정보를 제공합니다.
    * 신규 목록 조회용 API 엔드포인트가 추가되어 간편하게 목록을 받아볼 수 있습니다.
  * 성공 응답 코드 및 메시지 추가로 목록 조회 결과가 명확히 전달됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->