### PR TITLE
Refactor/#47 엔티티 수정 및 지원서 상세조회, 수정 로직 수정

### DIFF
--- a/.github/workflows/cd-prod.yaml
+++ b/.github/workflows/cd-prod.yaml
@@ -30,6 +30,6 @@ jobs:
             cd /home/ubuntu
             docker rm -f unionmate-prod || true
             docker compose pull unionmate-prod
-            docker compose restart
+            docker compose up -d --no-deps --force-recreate --pull always unionmate-prod
             docker compose exec nginx nginx -t && docker compose exec nginx nginx -s reload
             docker image prune -f

--- a/.github/workflows/cd-prod.yaml
+++ b/.github/workflows/cd-prod.yaml
@@ -30,5 +30,6 @@ jobs:
             cd /home/ubuntu
             docker rm -f unionmate-prod || true
             docker compose pull unionmate-prod
-            docker compose up -d --no-deps --force-recreate --pull always unionmate-prod
+            docker compose restart
+            docker compose exec nginx nginx -t && docker compose exec nginx nginx -s reload
             docker image prune -f

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/GetMyApplicationRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/request/GetMyApplicationRequest.java
@@ -3,7 +3,7 @@ package com.unionmate.backend.domain.applicant.application.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-public record GetMyApplicationsRequest(
+public record GetMyApplicationRequest(
 	@Schema(description = "지원자 이름", example = "김가천")
 	@NotBlank
 	String name,

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/CalendarAnswerResponse.java
@@ -20,9 +20,6 @@ public record CalendarAnswerResponse(
 	@Schema(description = "항목 설명 안내", example = "해당 날짜 전까지 희망하는 날짜를 작성해주세요")
 	String description,
 
-	@Schema(description = "날짜 지정", example = "2025-12-31")
-	LocalDate date,
-
 	@Schema(description = "답변 날짜")
 	LocalDate answer
 ) implements ApplicationAnswerResponse {
@@ -33,7 +30,6 @@ public record CalendarAnswerResponse(
 			calendarItem.getTitle(),
 			calendarItem.getOrder(),
 			calendarItem.getDescription(),
-			calendarItem.getDate(),
 			calendarItem.getAnswer() == null ? null : calendarItem.getAnswer().answer()
 		);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.unionmate.backend.domain.applicant.application.dto.request.AnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.CalendarAnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
-import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.SelectAnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.TextAnswerRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
@@ -168,10 +168,10 @@ public class ApplicationUseCase {
 
 	@Transactional
 	public void updateApplication(Long applicationId, UpdateApplicationRequest updateApplicationRequest,
-		GetMyApplicationsRequest getMyApplicationsRequest
+		GetMyApplicationRequest getMyApplicationRequest
 	) {
 		Application application = applicationGetService.getMyOneApplication(applicationId,
-			getMyApplicationsRequest.name(), getMyApplicationsRequest.email());
+			getMyApplicationRequest.name(), getMyApplicationRequest.email());
 		Recruitment recruitment = application.getRecruitment();
 
 		if (!recruitment.isOpen(LocalDateTime.now())) {
@@ -279,19 +279,19 @@ public class ApplicationUseCase {
 		applicationSaveService.save(application);
 	}
 
-	public List<GetMyApplicationsResponse> getMyApplications(GetMyApplicationsRequest getMyApplicationsRequest) {
+	public List<GetMyApplicationsResponse> getMyApplications(GetMyApplicationRequest getMyApplicationRequest) {
 		return applicationGetService.getMyApplications(
-				getMyApplicationsRequest.name(), getMyApplicationsRequest.email())
+				getMyApplicationRequest.name(), getMyApplicationRequest.email())
 			.stream()
 			.map(GetMyApplicationsResponse::from)
 			.toList();
 	}
 
 	public GetApplicationResponse getMyOneApplication(Long applicationId,
-		GetMyApplicationsRequest getMyApplicationsRequest
+		GetMyApplicationRequest getMyApplicationRequest
 	) {
 		Application application = applicationGetService.getMyOneApplication(applicationId,
-			getMyApplicationsRequest.name(), getMyApplicationsRequest.email()
+			getMyApplicationRequest.name(), getMyApplicationRequest.email()
 		);
 
 		return GetApplicationResponse.from(application);

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -167,8 +167,11 @@ public class ApplicationUseCase {
 	}
 
 	@Transactional
-	public void updateApplication(Long applicationId, UpdateApplicationRequest updateApplicationRequest) {
-		Application application = applicationGetService.getApplicationById(applicationId);
+	public void updateApplication(Long applicationId, UpdateApplicationRequest updateApplicationRequest,
+		GetMyApplicationsRequest getMyApplicationsRequest
+	) {
+		Application application = applicationGetService.getMyOneApplication(applicationId,
+			getMyApplicationsRequest.name(), getMyApplicationsRequest.email());
 		Recruitment recruitment = application.getRecruitment();
 
 		if (!recruitment.isOpen(LocalDateTime.now())) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -60,7 +60,7 @@ public class ApplicationUseCase {
 	private final CouncilManagerGetService councilManagerGetService;
 
 	private final ApplicationSaveService applicationSaveService;
-	
+
 	private final TextAnswerValidator textAnswerValidator;
 	private final SelectAnswerValidator selectAnswerValidator;
 	private final CalendarAnswerValidator calendarAnswerValidator;
@@ -284,8 +284,12 @@ public class ApplicationUseCase {
 			.toList();
 	}
 
-	public GetApplicationResponse getApplication(Long applicationId) {
-		Application application = applicationGetService.getApplicationById(applicationId);
+	public GetApplicationResponse getMyOneApplication(Long applicationId,
+		GetMyApplicationsRequest getMyApplicationsRequest
+	) {
+		Application application = applicationGetService.getMyOneApplication(applicationId,
+			getMyApplicationsRequest.name(), getMyApplicationsRequest.email()
+		);
 
 		return GetApplicationResponse.from(application);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/usecase/ApplicationUseCase.java
@@ -144,7 +144,7 @@ public class ApplicationUseCase {
 
 						CalendarItem calendarAnswer = CalendarItem.createApplicationCalendar(
 							application, calendarItem.getRequired(), calendarItem.getTitle(), calendarItem.getOrder(),
-							calendarItem.getDescription(), calendarItem.getDate()
+							calendarItem.getDescription()
 						);
 
 						calendarAnswer.updateAnswer(new Answer<>(calendarAnswerRequest.date()));
@@ -259,7 +259,7 @@ public class ApplicationUseCase {
 						} else {
 							CalendarItem newCalendarItem = CalendarItem.createApplicationCalendar(
 								application, calendarItem.getRequired(), calendarItem.getTitle(),
-								calendarItem.getOrder(), calendarItem.getDescription(), calendarItem.getDate()
+								calendarItem.getOrder(), calendarItem.getDescription()
 							);
 
 							newCalendarItem.updateAnswer(new Answer<>(calendarAnswerRequest.date()));

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -17,6 +17,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	boolean existsByRecruitmentId(Long recruitmentId);
 
+	Optional<Application> findByIdAndNameAndEmail(Long id, String name, String email);
+
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
 		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
@@ -33,6 +33,11 @@ public class ApplicationGetService {
 			.orElseThrow(ApplicationNotFoundException::new);
 	}
 
+	public Application getMyOneApplication(Long applicationId, String name, String email) {
+		return applicationRepository.findByIdAndNameAndEmail(applicationId, name, email)
+			.orElseThrow(ApplicationNotFoundException::new);
+	}
+
 	public List<CouncilApplicantQueryRow> getDocumentScreeningApplicantsForCouncil(
 		Council council, EvaluationStatus evaluationFilterOrNull
 	) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -93,8 +93,9 @@ public class ApplicationController {
 
 	@GetMapping("/{applicationId}")
 	@Operation(summary = "특정 지원서를 조회합니다.")
-	public CommonResponse<GetApplicationResponse> getApplication(@PathVariable Long applicationId) {
-		GetApplicationResponse application = applicationUseCase.getApplication(applicationId);
+	public CommonResponse<GetApplicationResponse> getApplication(@PathVariable Long applicationId,
+		@Valid GetMyApplicationsRequest getMyApplicationsRequest) {
+		GetApplicationResponse application = applicationUseCase.getMyOneApplication(applicationId, getMyApplicationsRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATION, application);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateApplicantRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.CreateCommentRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.DecisionRequest;
-import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationsRequest;
+import com.unionmate.backend.domain.applicant.application.dto.request.GetMyApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.SetInterviewScheduleRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateApplicationRequest;
 import com.unionmate.backend.domain.applicant.application.dto.request.UpdateCommentRequest;
@@ -57,9 +57,9 @@ public class ApplicationController {
 	@Operation(summary = "지원서를 수정합니다.")
 	public CommonResponse<Void> updateApplication(
 		@PathVariable Long applicationId, @Valid @RequestBody UpdateApplicationRequest updateApplicationRequest,
-		@Valid GetMyApplicationsRequest getMyApplicationsRequest
+		@Valid GetMyApplicationRequest getMyApplicationRequest
 	) {
-		applicationUseCase.updateApplication(applicationId, updateApplicationRequest, getMyApplicationsRequest);
+		applicationUseCase.updateApplication(applicationId, updateApplicationRequest, getMyApplicationRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.UPDATE_APPLICATION);
 	}
@@ -67,8 +67,8 @@ public class ApplicationController {
 	@GetMapping("/mine")
 	@Operation(summary = "자신이 작성한 지원서 목록을 조회합니다.")
 	public CommonResponse<List<GetMyApplicationsResponse>> getMyApplications(
-		@Valid GetMyApplicationsRequest getMyApplicationsRequest) {
-		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(getMyApplicationsRequest);
+		@Valid GetMyApplicationRequest getMyApplicationRequest) {
+		List<GetMyApplicationsResponse> myApplications = applicationUseCase.getMyApplications(getMyApplicationRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATIONS, myApplications);
 	}
@@ -95,8 +95,9 @@ public class ApplicationController {
 	@GetMapping("/{applicationId}")
 	@Operation(summary = "특정 지원서를 조회합니다.")
 	public CommonResponse<GetApplicationResponse> getApplication(@PathVariable Long applicationId,
-		@Valid GetMyApplicationsRequest getMyApplicationsRequest) {
-		GetApplicationResponse application = applicationUseCase.getMyOneApplication(applicationId, getMyApplicationsRequest);
+		@Valid GetMyApplicationRequest getMyApplicationRequest) {
+		GetApplicationResponse application = applicationUseCase.getMyOneApplication(applicationId,
+			getMyApplicationRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.GET_MY_APPLICATION, application);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/presentation/ApplicationController.java
@@ -56,9 +56,10 @@ public class ApplicationController {
 	@PatchMapping("/{applicationId}")
 	@Operation(summary = "지원서를 수정합니다.")
 	public CommonResponse<Void> updateApplication(
-		@PathVariable Long applicationId, @Valid @RequestBody UpdateApplicationRequest updateApplicationRequest
+		@PathVariable Long applicationId, @Valid @RequestBody UpdateApplicationRequest updateApplicationRequest,
+		@Valid GetMyApplicationsRequest getMyApplicationsRequest
 	) {
-		applicationUseCase.updateApplication(applicationId, updateApplicationRequest);
+		applicationUseCase.updateApplication(applicationId, updateApplicationRequest, getMyApplicationsRequest);
 
 		return CommonResponse.success(ApplicationResponseCode.UPDATE_APPLICATION);
 	}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/CreateItemRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/CreateItemRequest.java
@@ -1,6 +1,5 @@
 package com.unionmate.backend.domain.recruitment.application.dto.request;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
@@ -39,10 +38,6 @@ public record CreateItemRequest(
 	//text용
 	@Schema(description = "답변 최대 글자 수", example = "700")
 	Integer maxLength,
-
-	//calendar용
-	@Schema(description = "날짜 지정", example = "2001-06-15")
-	LocalDate date,
 
 	//announcement용
 	@Schema(description = "공지 내용 안내", example = "면접 장소는 AI 공학관 402호입니다.")

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/SelectOptionRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/SelectOptionRequest.java
@@ -7,12 +7,6 @@ public record SelectOptionRequest(
 	String title,
 
 	@Schema(description = "선택지 순서", example = "1")
-	Integer order,
-
-	@Schema(description = "기타 항목 여부", example = "false")
-	Boolean isEtc,
-
-	@Schema(description = "기타 항목 이름", example = "null")
-	String etcTitle
+	Integer order
 ) {
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/UpdateCalendarRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/UpdateCalendarRequest.java
@@ -20,9 +20,6 @@ public record UpdateCalendarRequest(
 	Integer order,
 
 	@Schema(description = "항목 설명", example = "희망하는 날짜를 선택해주세요")
-	String description,
-
-	@Schema(description = "날짜", example = "2025-11-30")
-	LocalDate date
+	String description
 ) implements UpdateItemRequest{
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/UpdateCalendarRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/UpdateCalendarRequest.java
@@ -1,6 +1,5 @@
 package com.unionmate.backend.domain.recruitment.application.dto.request;
 
-import java.time.LocalDate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/UpdateSelectOptionRequest.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/request/UpdateSelectOptionRequest.java
@@ -10,12 +10,6 @@ public record UpdateSelectOptionRequest(
 	String title,
 
 	@Schema(description = "선택지 순서", example = "1")
-	Integer order,
-
-	@Schema(description = "기타 여부", example = "true")
-	Boolean isEtc,
-
-	@Schema(description = "기타 항목 제목", example = "기타(입력해주세요.)")
-	String etcTitle
+	Integer order
 ) {
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/CalendarResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/CalendarResponse.java
@@ -24,10 +24,7 @@ public record CalendarResponse(
 	Integer order,
 
 	@Schema(description = "항목 설명 안내", example = "해당 날짜 전까지 희망하는 날짜를 작성해주세요")
-	String description,
-
-	@Schema(description = "날짜 지정", example = "2025-12-31")
-	LocalDate date
+	String description
 ) implements ItemResponse {
 
 	public static CalendarResponse from(CalendarItem calendarItem, ItemType itemType) {
@@ -37,8 +34,7 @@ public record CalendarResponse(
 			calendarItem.getRequired(),
 			calendarItem.getTitle(),
 			calendarItem.getOrder(),
-			calendarItem.getDescription(),
-			calendarItem.getDate()
+			calendarItem.getDescription()
 		);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/SelectOptionResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/dto/response/SelectOptionResponse.java
@@ -12,21 +12,13 @@ public record SelectOptionResponse(
 	String title,
 
 	@Schema(description = "선택 항목 순서", example = "1")
-	Integer order,
-
-	@Schema(description = "기타 항목 여부", example = "false")
-	Boolean isEtc,
-
-	@Schema(description = "기타 항목 이름", example = "null")
-	String etcTitle
+	Integer order
 ) {
 	public static SelectOptionResponse from(SelectItemOption selectItemOption) {
 		return new SelectOptionResponse(
 			selectItemOption.getId(),
 			selectItemOption.getTitle(),
-			selectItemOption.getOrder(),
-			selectItemOption.getIsEtc(),
-			selectItemOption.getEtcTitle()
+			selectItemOption.getOrder()
 		);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
@@ -186,8 +186,7 @@ public class RecruitmentUseCase {
 					for (SelectOptionRequest selectOptionRequest : createItemRequest.options()) {
 						selectItem.getSelectItemOptions().add(
 							SelectItemOption.createRecruitmentSelectOption(selectOptionRequest.title(),
-								selectOptionRequest.order(), Boolean.TRUE.equals(selectOptionRequest.isEtc()),
-								selectOptionRequest.etcTitle(), selectItem));
+								selectOptionRequest.order(), selectItem));
 					}
 				}
 				yield selectItem;
@@ -248,9 +247,7 @@ public class RecruitmentUseCase {
 								// 생성
 								if (updateSelectOptionRequest.id() == null) {
 									SelectItemOption newOptions = SelectItemOption.createRecruitmentSelectOption(
-										updateSelectOptionRequest.title(), updateSelectOptionRequest.order(),
-										Boolean.TRUE.equals(updateSelectOptionRequest.isEtc()),
-										updateSelectOptionRequest.etcTitle(), selectItem
+										updateSelectOptionRequest.title(), updateSelectOptionRequest.order(), selectItem
 									);
 
 									selectItem.getSelectItemOptions().add(newOptions);

--- a/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/application/usecase/RecruitmentUseCase.java
@@ -193,7 +193,7 @@ public class RecruitmentUseCase {
 			}
 
 			case CALENDAR -> CalendarItem.createRecruitmentCalendar(recruitment, required, createItemRequest.title(),
-				createItemRequest.order(), createItemRequest.description(), createItemRequest.date());
+				createItemRequest.order(), createItemRequest.description());
 
 			case ANNOUNCEMENT ->
 				AnnouncementItem.createRecruitmentAnnouncement(recruitment, required, createItemRequest.title(),
@@ -262,9 +262,8 @@ public class RecruitmentUseCase {
 							}
 						}
 					}
-					case
-						CalendarItem calendarItem when updateItemRequest instanceof UpdateCalendarRequest updateCalendarRequest ->
-						calendarItem.updateDate(updateCalendarRequest.date());
+					case CalendarItem calendarItem when updateItemRequest instanceof UpdateCalendarRequest -> {
+					}
 					case
 						AnnouncementItem announcementItem when updateItemRequest instanceof UpdateAnnouncementRequest updateAnnouncementRequest ->
 						announcementItem.updateAnnouncement(updateAnnouncementRequest.announcement());

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/item/CalendarItem.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/item/CalendarItem.java
@@ -28,46 +28,33 @@ import lombok.experimental.SuperBuilder;
 @DiscriminatorValue(DiscriminationValue.CALENDAR)
 public class CalendarItem extends Item {
 
-	//Single table 전략인데 하위 타입 전용 컬럼인 date를 nullable = false로 해서는 안됩니다.
-	//items 테이블에 모든 하위 컬럼이 있고, SELECT 타입을 insert할 때 값이 없는데도 not null을 요구한다면 오류가 생깁니다.
-	@Column(name = "date")
-	private LocalDate date;
-
 	@Convert(converter = LocalDateAnswerConverter.class)
 	@Lob
 	private Answer<LocalDate> answer;
-
-	public void updateDate(LocalDate date) {
-		if (date != null) {
-			this.date = date;
-		}
-	}
 
 	public void updateAnswer(Answer<LocalDate> answer) {
 		this.answer = answer;
 	}
 
 	public static CalendarItem createApplicationCalendar(Application application, Boolean required, String title,
-		Integer order, String description, LocalDate date) {
+		Integer order, String description) {
 		return CalendarItem.builder()
 			.application(application)
 			.required(required)
 			.title(title)
 			.order(order)
 			.description(description)
-			.date(date)
 			.build();
 	}
 
 	public static CalendarItem createRecruitmentCalendar(Recruitment recruitment, Boolean required, String title,
-		Integer order, String description, LocalDate date) {
+		Integer order, String description) {
 		return CalendarItem.builder()
 			.recruitment(recruitment)
 			.required(required)
 			.title(title)
 			.order(order)
 			.description(description)
-			.date(date)
 			.build();
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/item/SelectItemOption.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/entity/item/SelectItemOption.java
@@ -28,13 +28,6 @@ public class SelectItemOption extends BaseEntity {
 	@Column(name = "title", nullable = false)
 	private String title;
 
-	@Column(name = "is_etc", nullable = false)
-	@Builder.Default
-	private Boolean isEtc = false;
-
-	@Column(name = "etc_title")
-	private String etcTitle;
-
 	@Column(name = "orders", nullable = false)
 	private Integer order;
 
@@ -44,44 +37,21 @@ public class SelectItemOption extends BaseEntity {
 	private SelectItem selectItem;
 
 	public void updateTitle(String title) {
-		if(title != null) {
+		if (title != null) {
 			this.title = title;
 		}
 	}
 
-	public void updateIsEtc(Boolean isEtc) {
-		if(isEtc != null) {
-			this.isEtc = isEtc;
-		}
-	}
-
-	public void updateEtcTitle(String etcTitle) {
-		if(etcTitle != null) {
-			this.etcTitle = etcTitle;
-		}
-	}
-
 	public void updateOrder(Integer order) {
-		if(order != null) {
+		if (order != null) {
 			this.order = order;
 		}
 	}
 
-	@AssertTrue
-	public boolean validateEtc() {
-		if (Boolean.TRUE.equals(isEtc)) {
-			return this.etcTitle != null && !this.etcTitle.isEmpty();
-		}
-		return true;
-	}
-
-	public static SelectItemOption createRecruitmentSelectOption(String title, Integer order, Boolean isEtc,
-		String etcTitle, SelectItem selectItem) {
+	public static SelectItemOption createRecruitmentSelectOption(String title, Integer order, SelectItem selectItem) {
 		return SelectItemOption.builder()
 			.title(title)
 			.order(order)
-			.isEtc(isEtc)
-			.etcTitle(etcTitle)
 			.selectItem(selectItem)
 			.build();
 	}

--- a/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentFormUpdateService.java
+++ b/src/main/java/com/unionmate/backend/domain/recruitment/domain/service/RecruitmentFormUpdateService.java
@@ -32,7 +32,5 @@ public class RecruitmentFormUpdateService {
 		UpdateSelectOptionRequest updateSelectOptionRequest) {
 		selectItemOption.updateTitle(updateSelectOptionRequest.title());
 		selectItemOption.updateOrder(updateSelectOptionRequest.order());
-		selectItemOption.updateIsEtc(updateSelectOptionRequest.isEtc());
-		selectItemOption.updateEtcTitle(updateSelectOptionRequest.etcTitle());
 	}
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8000
 spring:
   application:
     name: backend-service

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8000
+  port: 8080
 spring:
   application:
     name: backend-service


### PR DESCRIPTION
## Related issue 🛠

- closed #47 

## 작업 내용 💻

- [x] CalendarItem의 date 필드를 삭제했습니다.
- [x] SelectOptionItem의 etc 관련 필드를 삭제했습니다.
- [x] 지원서 상세조회 시 이름과 이메일을 입력받아 일치하는지 검증하도록 수정했습니다.
- [x] 지원서 수정 시 이름과 이메일을 입력받아 일치하는지 검증하도록 수정했습니다.

## 스크린샷 📷

- 지원서 조회 시 다음과 같이 이름과 이메일을 입력해야하도록 구현했습니다.
<img width="1485" height="636" alt="image" src="https://github.com/user-attachments/assets/271e6f18-1efa-4c15-ae66-fdfde0444bde" />

- 지원서 수정 시 다음과 같이 이름과 이메일을 입력해야하도록 구현했습니다.
<img width="1478" height="618" alt="image" src="https://github.com/user-attachments/assets/8e50bc63-0bc1-4c7b-b8b7-9be4d1eaf9c9" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 신청서 조회 시 사용자 인증 기반 접근 제어 강화
  * 캘린더 항목과 선택 옵션에서 불필요한 필드 제거로 API 응답 데이터 구조 단순화
  * 신청서 관리 API 업데이트로 보안성 개선

* **Chores**
  * 프로덕션 배포 프로세스 최적화 및 Nginx 설정 검증 자동화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->