### PR TITLE
Refactor/#53 서류 심사, 면접 심사 리스트 조회 시 recruitmentStatus가 응답되도록 추가 

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -43,7 +43,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -56,7 +56,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -69,7 +69,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -82,7 +82,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -97,7 +97,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -110,7 +110,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -123,7 +123,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -25,7 +25,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -25,7 +25,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -43,7 +43,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -56,7 +56,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -69,7 +69,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -82,7 +82,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -97,7 +97,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -110,7 +110,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r
@@ -123,7 +123,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
-		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, r.recruitmentStatus
+		    a.name, a.email, a.tel, a.createdAt, a.stage.evaluationStatus, a.stage.recruitmentStatus
 		)
 		from Application a
 		    join a.recruitment r

--- a/src/main/java/com/unionmate/backend/domain/council/application/dto/CouncilApplicantQueryRow.java
+++ b/src/main/java/com/unionmate/backend/domain/council/application/dto/CouncilApplicantQueryRow.java
@@ -3,17 +3,20 @@ package com.unionmate.backend.domain.council.application.dto;
 import java.time.LocalDateTime;
 
 import com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus;
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
 
 public record CouncilApplicantQueryRow(
 	String name,
 	String email,
 	String tel,
 	LocalDateTime appliedAt,
-	EvaluationStatus evaluationStatus
+	EvaluationStatus evaluationStatus,
+	RecruitmentStatus recruitmentStatus
 ) {
 	public static CouncilApplicantQueryRow of(
-		String name, String email, String tel, LocalDateTime appliedAt, EvaluationStatus evaluationStatus
+		String name, String email, String tel, LocalDateTime appliedAt, EvaluationStatus evaluationStatus,
+		RecruitmentStatus recruitmentStatus
 	) {
-		return new CouncilApplicantQueryRow(name, email, tel, appliedAt, evaluationStatus);
+		return new CouncilApplicantQueryRow(name, email, tel, appliedAt, evaluationStatus, recruitmentStatus);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/council/application/dto/CouncilApplicantResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/council/application/dto/CouncilApplicantResponse.java
@@ -3,6 +3,7 @@ package com.unionmate.backend.domain.council.application.dto;
 import java.time.LocalDateTime;
 
 import com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus;
+import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -21,11 +22,15 @@ public record CouncilApplicantResponse(
 	LocalDateTime appliedAt,
 
 	@Schema(description = "평가 상태", example = "FAILED", allowableValues = {"SUBMITTED", "FAILED", "PASSED"})
-	EvaluationStatus evaluationStatus
+	EvaluationStatus evaluationStatus,
+
+	@Schema(description = "지원서 상태", example = "INTERVIEW")
+	RecruitmentStatus recruitmentStatus
 ) {
 	public static CouncilApplicantResponse of(
-		String name, String email, String tel, LocalDateTime appliedAt, EvaluationStatus evaluationStatus
+		String name, String email, String tel, LocalDateTime appliedAt, EvaluationStatus evaluationStatus,
+		RecruitmentStatus recruitmentStatus
 	) {
-		return new CouncilApplicantResponse(name, email, tel, appliedAt, evaluationStatus);
+		return new CouncilApplicantResponse(name, email, tel, appliedAt, evaluationStatus, recruitmentStatus);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
+++ b/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
@@ -124,7 +124,7 @@ public class CouncilManageUsecase {
 
 		return rows.stream()
 			.map(row -> CouncilApplicantResponse.of(
-				row.name(), row.email(), row.tel(), row.appliedAt(), row.evaluationStatus()
+				row.name(), row.email(), row.tel(), row.appliedAt(), row.evaluationStatus(), row.recruitmentStatus()
 			))
 			.toList();
 	}
@@ -141,7 +141,7 @@ public class CouncilManageUsecase {
 
 		return rows.stream()
 			.map(row -> CouncilApplicantResponse.of(
-				row.name(), row.email(), row.tel(), row.appliedAt(), row.evaluationStatus()
+				row.name(), row.email(), row.tel(), row.appliedAt(), row.evaluationStatus(), row.recruitmentStatus()
 			))
 			.toList();
 	}


### PR DESCRIPTION
## Related issue 🛠

- closed #53 

## 작업 내용 💻

- [x] 서류 심사 리스트 조회 시 recruitmentStatus가 응답되도록 수정했습니다.
- [x] 면접 심사 리스트 조회 시 recruitmentStatus가 응답되도록 수정했습니다.

## 스크린샷 📷

- 서류 심사 리스트 조회
<img width="1407" height="293" alt="image" src="https://github.com/user-attachments/assets/e186913d-ee39-4848-bef7-e6aabcde3550" />

<hr>

- 면접 심사 리스트 조회
<img width="1411" height="289" alt="image" src="https://github.com/user-attachments/assets/c9c9fd6a-da59-4b95-9f3f-a72986897253" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신청자 정보 조회 시 모집 상태 정보가 추가되었습니다.
  * 신청 현황 조회 및 신청자 목록에서 모집 상태를 함께 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->