### PR TITLE
Refactor/#55 지원서 조회 시 선택항목의 id, title 모두 반환되도록 수정 및 추가 수정

### DIFF
--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/ApplicationAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/ApplicationAnswerResponse.java
@@ -1,5 +1,7 @@
 package com.unionmate.backend.domain.applicant.application.dto.response;
 
+import java.util.Map;
+
 import com.unionmate.backend.domain.recruitment.application.exception.ItemTypeNotExistException;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.CalendarItem;
@@ -17,10 +19,10 @@ public sealed interface ApplicationAnswerResponse
 
 	String description();
 
-	static ApplicationAnswerResponse from(Item item) {
+	static ApplicationAnswerResponse from(Item item, Map<Long, String> selectOptionTitleById) {
 		return switch (item) {
 			case TextItem textItem -> TextAnswerResponse.from(textItem);
-			case SelectItem selectItem -> SelectAnswerResponse.from(selectItem);
+			case SelectItem selectItem -> SelectAnswerResponse.from(selectItem, selectOptionTitleById);
 			case CalendarItem calendarItem -> CalendarAnswerResponse.from(calendarItem);
 			default -> throw new ItemTypeNotExistException();
 		};

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationAdminResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationAdminResponse.java
@@ -3,12 +3,17 @@ package com.unionmate.backend.domain.applicant.application.dto.response;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
 import com.unionmate.backend.domain.applicant.domain.entity.embed.Interview;
 import com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus;
+import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItemOption;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -37,9 +42,11 @@ public record GetApplicationAdminResponse(
 	LocalDateTime submittedAt
 ) {
 	public static GetApplicationAdminResponse from(Application application) {
+		Map<Long, String> selectOptionTitleById = buildSelectOptionTitleMap(application.getRecruitment());
+
 		List<ApplicationAnswerResponse> sortedAnswers = application.getAnswers().stream()
 			.sorted(Comparator.comparing(Item::getOrder))
-			.map(ApplicationAnswerResponse::from)
+			.map(item -> ApplicationAnswerResponse.from(item, selectOptionTitleById))
 			.toList();
 
 		InterviewResponse interviewResponse = from(application.getInterview());
@@ -117,5 +124,16 @@ public record GetApplicationAdminResponse(
 		@Schema(description = "면접 장소", example = "판교 플레이그라운드 5층 B-회의실")
 		String place
 	) {
+	}
+
+	private static Map<Long, String> buildSelectOptionTitleMap(Recruitment recruitment) {
+		return recruitment.getItems().stream()
+			.filter(item -> item instanceof SelectItem)
+			.map(item -> (SelectItem)item)
+			.flatMap(selectItem -> selectItem.getSelectItemOptions().stream())
+			.collect(Collectors.toMap(
+				SelectItemOption::getId,
+				SelectItemOption::getTitle
+			));
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationAdminResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationAdminResponse.java
@@ -42,11 +42,11 @@ public record GetApplicationAdminResponse(
 	LocalDateTime submittedAt
 ) {
 	public static GetApplicationAdminResponse from(Application application) {
-		Map<Long, String> selectOptionTitleById = buildSelectOptionTitleMap(application.getRecruitment());
+		Map<Long, String> selectOptions = buildSelectOptionMap(application.getRecruitment());
 
 		List<ApplicationAnswerResponse> sortedAnswers = application.getAnswers().stream()
 			.sorted(Comparator.comparing(Item::getOrder))
-			.map(item -> ApplicationAnswerResponse.from(item, selectOptionTitleById))
+			.map(item -> ApplicationAnswerResponse.from(item, selectOptions))
 			.toList();
 
 		InterviewResponse interviewResponse = from(application.getInterview());
@@ -126,7 +126,7 @@ public record GetApplicationAdminResponse(
 	) {
 	}
 
-	private static Map<Long, String> buildSelectOptionTitleMap(Recruitment recruitment) {
+	private static Map<Long, String> buildSelectOptionMap(Recruitment recruitment) {
 		return recruitment.getItems().stream()
 			.filter(item -> item instanceof SelectItem)
 			.map(item -> (SelectItem)item)

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
@@ -2,9 +2,14 @@ package com.unionmate.backend.domain.applicant.application.dto.response;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.unionmate.backend.domain.applicant.domain.entity.Application;
+import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.Item;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
+import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItemOption;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -29,9 +34,11 @@ public record GetApplicationResponse(
 	List<ApplicationAnswerResponse> answers
 ) {
 	public static GetApplicationResponse from(Application application) {
+		Map<Long, String> selectOptionTitleById = buildSelectOptionTitleMap(application.getRecruitment());
+
 		List<ApplicationAnswerResponse> answer = application.getAnswers().stream()
 			.sorted(Comparator.comparing(Item::getOrder))
-			.map(ApplicationAnswerResponse::from)
+			.map(item -> ApplicationAnswerResponse.from(item, selectOptionTitleById))
 			.toList();
 
 		return new GetApplicationResponse(
@@ -43,5 +50,16 @@ public record GetApplicationResponse(
 			application.getTel(),
 			answer
 		);
+	}
+
+	private static Map<Long, String> buildSelectOptionTitleMap(Recruitment recruitment) {
+		return recruitment.getItems().stream()
+			.filter(item -> item instanceof SelectItem)
+			.map(item -> (SelectItem)item)
+			.flatMap(selectItem -> selectItem.getSelectItemOptions().stream())
+			.collect(Collectors.toMap(
+				SelectItemOption::getId,
+				SelectItemOption::getTitle
+			));
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/GetApplicationResponse.java
@@ -34,11 +34,11 @@ public record GetApplicationResponse(
 	List<ApplicationAnswerResponse> answers
 ) {
 	public static GetApplicationResponse from(Application application) {
-		Map<Long, String> selectOptionTitleById = buildSelectOptionTitleMap(application.getRecruitment());
+		Map<Long, String> selectOptions = buildSelectOptionMap(application.getRecruitment());
 
 		List<ApplicationAnswerResponse> answer = application.getAnswers().stream()
 			.sorted(Comparator.comparing(Item::getOrder))
-			.map(item -> ApplicationAnswerResponse.from(item, selectOptionTitleById))
+			.map(item -> ApplicationAnswerResponse.from(item, selectOptions))
 			.toList();
 
 		return new GetApplicationResponse(
@@ -52,7 +52,7 @@ public record GetApplicationResponse(
 		);
 	}
 
-	private static Map<Long, String> buildSelectOptionTitleMap(Recruitment recruitment) {
+	private static Map<Long, String> buildSelectOptionMap(Recruitment recruitment) {
 		return recruitment.getItems().stream()
 			.filter(item -> item instanceof SelectItem)
 			.map(item -> (SelectItem)item)

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -31,7 +31,7 @@ public record SelectAnswerResponse(
 	public static SelectAnswerResponse from(SelectItem selectItem, Map<Long, String> selectOptionTitleById) {
 		List<Long> selectOptionIds = selectItem.getAnswer() == null ? List.of() : selectItem.getAnswer().answer();
 
-		List<SelectOptionAnswerResponse> selectOptionTitles = selectOptionIds.stream()
+		List<SelectOptionAnswerResponse> selectOptions = selectOptionIds.stream()
 			.map(optionId -> new SelectOptionAnswerResponse(optionId, selectOptionTitleById.get(optionId)))
 			.toList();
 
@@ -41,7 +41,7 @@ public record SelectAnswerResponse(
 			selectItem.getOrder(),
 			selectItem.getDescription(),
 			selectItem.isMultiple(),
-			selectOptionTitles
+			selectOptions
 		);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -1,6 +1,7 @@
 package com.unionmate.backend.domain.applicant.application.dto.response;
 
 import java.util.List;
+import java.util.Map;
 
 import com.unionmate.backend.domain.recruitment.domain.entity.enums.ItemType;
 import com.unionmate.backend.domain.recruitment.domain.entity.item.SelectItem;
@@ -23,18 +24,28 @@ public record SelectAnswerResponse(
 	@Schema(description = "중복 선택 가능 여부 ", example = "false")
 	boolean multiple,
 
-	@Schema(description = "답변한 선택지")
-	List<Long> selectedOptionIds
+	@Schema(description = "답변한 선택지 id")
+	List<Long> selectedOptionIds,
+
+	@Schema(description = "답변한 선택지 이름")
+	List<SelectOptionAnswerResponse> selectOptions
 ) implements ApplicationAnswerResponse {
 
-	public static SelectAnswerResponse from(SelectItem selectItem) {
+	public static SelectAnswerResponse from(SelectItem selectItem, Map<Long, String> selectOptionTitleById) {
+		List<Long> selectOptionIds = selectItem.getAnswer() == null ? List.of() : selectItem.getAnswer().answer();
+
+		List<SelectOptionAnswerResponse> selectOptionTitles = selectOptionIds.stream()
+			.map(optionId -> new SelectOptionAnswerResponse(optionId, selectOptionTitleById.get(optionId)))
+			.toList();
+
 		return new SelectAnswerResponse(
 			ItemType.SELECT,
 			selectItem.getTitle(),
 			selectItem.getOrder(),
 			selectItem.getDescription(),
 			selectItem.isMultiple(),
-			selectItem.getAnswer() == null ? List.of() : selectItem.getAnswer().answer()
+			selectOptionIds,
+			selectOptionTitles
 		);
 	}
 }

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectAnswerResponse.java
@@ -24,10 +24,7 @@ public record SelectAnswerResponse(
 	@Schema(description = "중복 선택 가능 여부 ", example = "false")
 	boolean multiple,
 
-	@Schema(description = "답변한 선택지 id")
-	List<Long> selectedOptionIds,
-
-	@Schema(description = "답변한 선택지 이름")
+	@Schema(description = "답변한 선택지 항목")
 	List<SelectOptionAnswerResponse> selectOptions
 ) implements ApplicationAnswerResponse {
 
@@ -44,7 +41,6 @@ public record SelectAnswerResponse(
 			selectItem.getOrder(),
 			selectItem.getDescription(),
 			selectItem.isMultiple(),
-			selectOptionIds,
 			selectOptionTitles
 		);
 	}

--- a/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectOptionAnswerResponse.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/application/dto/response/SelectOptionAnswerResponse.java
@@ -1,0 +1,12 @@
+package com.unionmate.backend.domain.applicant.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SelectOptionAnswerResponse(
+	@Schema(description = "선택지 id", example = "1")
+	Long optionId,
+
+	@Schema(description = "선택지 title", example = "월요일")
+	String title
+) {
+}

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/repository/ApplicationRepository.java
@@ -29,7 +29,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and (
 		        a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.DOCUMENT_SCREENING
 		        or (
@@ -39,7 +39,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		      )
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findDocumentListNoFilter(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findDocumentListNoFilter(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -47,12 +47,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.DOCUMENT_SCREENING
 		  and a.stage.evaluationStatus = com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus.SUBMITTED
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findDocumentListSubmitted(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findDocumentListSubmitted(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -60,12 +60,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.INTERVIEW
 		  and a.stage.evaluationStatus = com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus.SUBMITTED
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findDocumentListPassed(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findDocumentListPassed(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -73,12 +73,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.DOCUMENT_SCREENING
 		  and a.stage.evaluationStatus = com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus.FAILED
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findDocumentListFailed(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findDocumentListFailed(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -86,14 +86,14 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus in (
 		      com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.INTERVIEW,
 		      com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.FINAL
 		  )
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findInterviewListNoFilter(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findInterviewListNoFilter(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -101,12 +101,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.INTERVIEW
 		  and a.stage.evaluationStatus = com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus.SUBMITTED
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findInterviewListSubmitted(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findInterviewListSubmitted(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -114,12 +114,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.FINAL
 		  and a.stage.evaluationStatus = com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus.PASSED
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findInterviewListPassed(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findInterviewListPassed(@Param("recruitment") Recruitment recruitment);
 
 	@Query("""
 		select new com.unionmate.backend.domain.council.application.dto.CouncilApplicantQueryRow(
@@ -127,12 +127,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 		)
 		from Application a
 		    join a.recruitment r
-		where r.council = :council
+		where r = :recruitment
 		  and a.stage.recruitmentStatus = com.unionmate.backend.domain.recruitment.domain.entity.enums.RecruitmentStatus.FINAL
 		  and a.stage.evaluationStatus = com.unionmate.backend.domain.applicant.domain.entity.enums.EvaluationStatus.FAILED
 		order by a.id desc
 		""")
-	List<CouncilApplicantQueryRow> findInterviewListFailed(@Param("council") Council council);
+	List<CouncilApplicantQueryRow> findInterviewListFailed(@Param("recruitment") Recruitment recruitment);
 
 	@EntityGraph(attributePaths = {"recruitment", "recruitment.council", "answers"})
 	@Query("select a from Application a where a.id = :id")

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
@@ -66,7 +66,7 @@ public class ApplicationGetService {
 		};
 	}
 
-	public List<CouncilApplicantQueryRow> getInterviewApplicantsForCouncil(
+	public List<CouncilApplicantQueryRow> getInterviewApplicantsForRecruitment(
 		Recruitment recruitment, EvaluationStatus evaluationFilterOrNull
 	) {
 		if (evaluationFilterOrNull == null) {

--- a/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
+++ b/src/main/java/com/unionmate/backend/domain/applicant/domain/service/ApplicationGetService.java
@@ -51,33 +51,33 @@ public class ApplicationGetService {
 			.orElseThrow(ApplicationNotFoundException::new);
 	}
 
-	public List<CouncilApplicantQueryRow> getDocumentScreeningApplicantsForCouncil(
-		Council council, EvaluationStatus evaluationFilterOrNull
+	public List<CouncilApplicantQueryRow> getDocumentScreeningApplicantsForRecruitment(
+		Recruitment recruitment, EvaluationStatus evaluationFilterOrNull
 	) {
 		if (evaluationFilterOrNull == null) {
 
-			return applicationRepository.findDocumentListNoFilter(council);
+			return applicationRepository.findDocumentListNoFilter(recruitment);
 		}
 		return switch (evaluationFilterOrNull) {
-			case SUBMITTED -> applicationRepository.findDocumentListSubmitted(council);
-			case PASSED -> applicationRepository.findDocumentListPassed(council);
-			case FAILED -> applicationRepository.findDocumentListFailed(council);
-			default -> applicationRepository.findDocumentListNoFilter(council);
+			case SUBMITTED -> applicationRepository.findDocumentListSubmitted(recruitment);
+			case PASSED -> applicationRepository.findDocumentListPassed(recruitment);
+			case FAILED -> applicationRepository.findDocumentListFailed(recruitment);
+			default -> applicationRepository.findDocumentListNoFilter(recruitment);
 		};
 	}
 
 	public List<CouncilApplicantQueryRow> getInterviewApplicantsForCouncil(
-		Council council, EvaluationStatus evaluationFilterOrNull
+		Recruitment recruitment, EvaluationStatus evaluationFilterOrNull
 	) {
 		if (evaluationFilterOrNull == null) {
 
-			return applicationRepository.findInterviewListNoFilter(council);
+			return applicationRepository.findInterviewListNoFilter(recruitment);
 		}
 		return switch (evaluationFilterOrNull) {
-			case SUBMITTED -> applicationRepository.findInterviewListSubmitted(council);
-			case PASSED -> applicationRepository.findInterviewListPassed(council);
-			case FAILED -> applicationRepository.findInterviewListFailed(council);
-			default -> applicationRepository.findInterviewListNoFilter(council);
+			case SUBMITTED -> applicationRepository.findInterviewListSubmitted(recruitment);
+			case PASSED -> applicationRepository.findInterviewListPassed(recruitment);
+			case FAILED -> applicationRepository.findInterviewListFailed(recruitment);
+			default -> applicationRepository.findInterviewListNoFilter(recruitment);
 		};
 	}
 

--- a/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
+++ b/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
@@ -144,7 +144,7 @@ public class CouncilManageUsecase {
 		councilManager.validateBelongsToCouncil(councilManager, council);
 
 		List<CouncilApplicantQueryRow> rows =
-			applicationGetService.getInterviewApplicantsForRecruitment(dd recruitment, evaluationFilterOrNull);
+			applicationGetService.getInterviewApplicantsForRecruitment(recruitment, evaluationFilterOrNull);
 
 		return rows.stream()
 			.map(row -> CouncilApplicantResponse.of(

--- a/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
+++ b/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
@@ -144,7 +144,7 @@ public class CouncilManageUsecase {
 		councilManager.validateBelongsToCouncil(councilManager, council);
 
 		List<CouncilApplicantQueryRow> rows =
-			applicationGetService.getInterviewApplicantsForCouncil(recruitment, evaluationFilterOrNull);
+			applicationGetService.getInterviewApplicantsForRecruitment(dd recruitment, evaluationFilterOrNull);
 
 		return rows.stream()
 			.map(row -> CouncilApplicantResponse.of(

--- a/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
+++ b/src/main/java/com/unionmate/backend/domain/council/application/usecase/CouncilManageUsecase.java
@@ -27,6 +27,8 @@ import com.unionmate.backend.domain.member.domain.entity.Member;
 import com.unionmate.backend.domain.member.domain.entity.School;
 import com.unionmate.backend.domain.member.domain.service.MemberGetService;
 import com.unionmate.backend.domain.member.domain.service.SchoolGetService;
+import com.unionmate.backend.domain.recruitment.domain.entity.Recruitment;
+import com.unionmate.backend.domain.recruitment.domain.service.RecruitmentGetService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -39,6 +41,7 @@ public class CouncilManageUsecase {
 	private final ApplicationGetService applicationGetService;
 	private final CouncilManagerGetService councilManagerGetService;
 	private final CouncilGetService councilGetService;
+	private final RecruitmentGetService recruitmentGetService;
 
 	private final CouncilSaveService councilSaveService;
 	private final CouncilManagerSaveService councilManagerSaveService;
@@ -113,14 +116,16 @@ public class CouncilManageUsecase {
 	}
 
 	public List<CouncilApplicantResponse> getDocumentScreeningApplicants(
-		long memberId, long councilId, EvaluationStatus evaluationFilterOrNull
+		long memberId, long recruitmentId, EvaluationStatus evaluationFilterOrNull
 	) {
+		Recruitment recruitment = recruitmentGetService.getRecruitmentById(recruitmentId);
+
 		CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(memberId);
-		Council council = councilGetService.getCouncilById(councilId);
+		Council council = recruitment.getCouncil();
 		councilManager.validateBelongsToCouncil(councilManager, council);
 
 		List<CouncilApplicantQueryRow> rows =
-			applicationGetService.getDocumentScreeningApplicantsForCouncil(council, evaluationFilterOrNull);
+			applicationGetService.getDocumentScreeningApplicantsForRecruitment(recruitment, evaluationFilterOrNull);
 
 		return rows.stream()
 			.map(row -> CouncilApplicantResponse.of(
@@ -130,14 +135,16 @@ public class CouncilManageUsecase {
 	}
 
 	public List<CouncilApplicantResponse> getInterviewApplicants(
-		long memberId, long councilId, EvaluationStatus evaluationFilterOrNull
+		long memberId, long recruitmentId, EvaluationStatus evaluationFilterOrNull
 	) {
+		Recruitment recruitment = recruitmentGetService.getRecruitmentById(recruitmentId);
+
 		CouncilManager councilManager = councilManagerGetService.getCouncilManagerByMemberId(memberId);
-		Council council = councilGetService.getCouncilById(councilId);
+		Council council = recruitment.getCouncil();
 		councilManager.validateBelongsToCouncil(councilManager, council);
 
 		List<CouncilApplicantQueryRow> rows =
-			applicationGetService.getInterviewApplicantsForCouncil(council, evaluationFilterOrNull);
+			applicationGetService.getInterviewApplicantsForCouncil(recruitment, evaluationFilterOrNull);
 
 		return rows.stream()
 			.map(row -> CouncilApplicantResponse.of(

--- a/src/main/java/com/unionmate/backend/domain/council/presentation/CouncilController.java
+++ b/src/main/java/com/unionmate/backend/domain/council/presentation/CouncilController.java
@@ -119,14 +119,14 @@ public class CouncilController {
 			- result=FAILED    : DOCUMENT_SCREENING + FAILED
 			"""
 	)
-	@GetMapping("/{councilId}/applications/document-screening")
+	@GetMapping("/{recruitmentId}/applications/document-screening")
 	public CommonResponse<List<CouncilApplicantResponse>> getDocumentScreeningApplicants(
 		@CurrentMemberId long memberId,
-		@PathVariable long councilId,
+		@PathVariable long recruitmentId,
 		@RequestParam(name = "result", required = false) EvaluationStatus evaluationStatus
 	) {
 		List<CouncilApplicantResponse> response = councilManageUsecase.getDocumentScreeningApplicants(memberId,
-			councilId, evaluationStatus);
+			recruitmentId, evaluationStatus);
 
 		return CommonResponse.success(COUNCIL_DOCUMENT_LIST, response);
 	}
@@ -140,13 +140,13 @@ public class CouncilController {
 			- result=FAILED    : FINAL + FAILED
 			"""
 	)
-	@GetMapping("/{councilId}/applications/interview")
+	@GetMapping("/{recruitmentId}/applications/interview")
 	public CommonResponse<List<CouncilApplicantResponse>> getInterviewApplicants(
 		@CurrentMemberId long memberId,
-		@PathVariable long councilId,
+		@PathVariable long recruitmentId,
 		@RequestParam(name = "result", required = false) EvaluationStatus evaluationStatus
 	) {
-		List<CouncilApplicantResponse> response = councilManageUsecase.getInterviewApplicants(memberId, councilId,
+		List<CouncilApplicantResponse> response = councilManageUsecase.getInterviewApplicants(memberId, recruitmentId,
 			evaluationStatus);
 
 		return CommonResponse.success(COUNCIL_INTERVIEW_LIST, response);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8000
 spring:
   application:
     name: backend-service

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8000
+  port: 8080
 spring:
   application:
     name: backend-service


### PR DESCRIPTION
## Related issue 🛠

- closed #55 

## 작업 내용 💻

- [x] 지원서 조회 시 선택항목의 id와 title이 모두 반환되도록 수정했습니다.
- [x] 관리자 전용 지원서 조회 시 선택항목의 id와 title이 모두 반환되도록 수정했습니다.
- [x] 학생회 면접/서류 심사 리스트 조회 시 앤드포인트 및 조회 기준을 councilId가 아닌 recruitmentId로 수정했습니다.

## 스크린샷 📷

- 지원서 조회 시 선택항목의 id, tite이 모두 반환됩니다.  
<img width="1418" height="577" alt="image" src="https://github.com/user-attachments/assets/4bf72564-2f15-487a-a832-cfee0f26f09f" />

<hr>

- 학생회 면접/서류 심사 리스트 조회 시 recruitmentId를 기준으로 조회되도록 수정했습니다.
<img width="1445" height="818" alt="image" src="https://github.com/user-attachments/assets/bdfa3374-657b-46f0-8bb5-a041576cddc4" />
<img width="1461" height="645" alt="image" src="https://github.com/user-attachments/assets/1a9ce6b0-f1f1-4671-ba68-8ae5c1664954" />



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 선택형 응답에 선택지 ID 대신 옵션 제목을 함께 반환하도록 응답 형식 추가(옵션 id + 제목 포함).

* **개선 사항**
  * 지원자 조회 응답에 선택지 제목 매핑을 포함해 응답 가독성 향상.
  * 서류/면접 조회 관련 API 및 내부 호출이 협의회 ID 기반에서 채용 ID 기반으로 변경되어 식별이 명확해짐.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->